### PR TITLE
Fix for account comparison - single organization

### DIFF
--- a/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
@@ -29,7 +29,7 @@ module.controller('WidgetAccountsComparisonCtrl', ($scope, $q, ChartFormatterSvc
       value: false,
       onChangeCallback: $scope.multiCompanyComparisonOnChange
     }]
-    if angular.isDefined w.metadata.comparison_mode
+    if angular.isDefined(w.metadata.comparison_mode) && w.metadata.organization_ids.length > 1
       angular.merge $scope.comparisonModeOptions, w.metadata.comparison_mode
     $scope.movedAccount = {}
 


### PR DESCRIPTION
Prevents running comparison mode or loading comparison mode from metadata settings if there aren't two or more organisations available on the widget.
This catches discrepancies between widget.metadata and the potential changes in availability of multiple organisations.

@cesar-tonnoir @ouranos This merge request will fix the widget being unusable in some cases.

On a seperate branch (xaun/rework/accounts-comparison) I have removed the grouping functionality from the front-end and hooked it up to the grouping function I wrote in Impac API. It's working much better, but it is not finished, I need to write some of the front-end behaviour logic outlined here:  https://github.com/maestrano/impac-angular/issues/6

:v: 