### PR TITLE
Removed grouping functionality from front-end

### DIFF
--- a/src/components/widgets-settings/account/account.tmpl.html
+++ b/src/components/widgets-settings/account/account.tmpl.html
@@ -1,9 +1,4 @@
 <h5 ng-if="showLabel">{{label}}</h5>
 <div class="input-group settings select-account">
-<!-- <<<<<<< HEAD
-	<select ng-model="parentWidget.selectedAccount" ng-change="onAccountSelected()" ng-options="account.name + ' (' + formatAmount(account) + ')' for account in parentWidget.content.account_list track by account.uid" class="form-control" />
-</div>
-======= -->
 	<select ng-model="parentWidget.selectedAccount" ng-change="onAccountSelected()" ng-options="formatLabel(account) for account in parentWidget.content.account_list track by account.uid" class="form-control" />
 </div>
-<!-- >>>>>>> develop -->

--- a/src/components/widgets-settings/accounts-list/accounts-list.directive.coffee
+++ b/src/components/widgets-settings/accounts-list/accounts-list.directive.coffee
@@ -61,7 +61,6 @@ module.directive('settingAccountsList', () ->
     scope: {
       parentWidget: '='
       deferred: '='
-      callbacks: '=?'
     },
     controller: 'SettingAccountsListCtrl'
   }

--- a/src/components/widgets-settings/accounts-list/accounts-list.directive.coffee
+++ b/src/components/widgets-settings/accounts-list/accounts-list.directive.coffee
@@ -19,50 +19,6 @@ module.controller('SettingAccountsListCtrl', ($scope, ImpacWidgetsSvc) ->
     ImpacWidgetsSvc.updateWidgetSettings(w, false) if triggerUpdate
     return null
 
-  # collection wrapper for w.moveAccountToAnotherList
-  w.clearAccounts = (src, dst, triggerUpdate=false) ->
-    srcCopy = angular.copy(src)
-    _.forEach(srcCopy, (account) -> w.moveAccountToAnotherList(account, src, dst, triggerUpdate))
-    return null
-
-  # keeps local of src accounts for switching between grouped and ungrouped.
-  stashedAccounts = []
-  # groups accounts by a string matcher, from a src collection, into a destination collection.
-  # note: src collection can be the dst collection. Src will be cleared.
-  w.groupAccounts = (src, dst, groupByKey, regExp) ->
-    grouped = []
-    counter = 0
-    rgx = new RegExp(regExp || /[^a-z0-9]/g)
-    stashedAccounts = angular.copy(src)
-    normalise = (str) -> str.toLowerCase().replace(rgx, "")
-    collectBalance = (arr) -> _.reduce(arr, (total, n) -> total + n )
-    sort = ->
-      baseAccount = src.shift()
-      matcher = normalise(baseAccount[groupByKey])
-      group = { name: baseAccount.account_name || baseAccount.name, uid: counter++ }
-      group.accounts = _.select src, (acc, index) ->
-        src.splice(index, 1)[0] if !!acc && normalise(acc[groupByKey]) == matcher
-      if group.accounts.length > 0
-        group.accounts.unshift(baseAccount)
-        # TODO::multi-currency: support for conversions across multi-currency, multi-company accounts.
-        group.current_balance = collectBalance(_.map(group.accounts, (acc) -> acc.current_balance))
-        group.currency = _.map(group.accounts, (acc) -> acc.currency).join('/')
-        grouped.push(group)
-      unless src.length
-        _.forEach(grouped, (acc) -> dst.push(acc) )
-      else
-        sort()
-    sort()
-
-  # ungroups by removing manipulated(grouped) objects (src), and restores original accounts by re-applying stashedAccounts to dst.
-  w.ungroupAccounts = (src, dst) ->
-    src.length = 0
-    _.forEach(stashedAccounts, (acc) -> src.push(acc) )
-    stashedAccounts = []
-
-  # applys comparison_mode setting data to either filter or not filter accounts on load.
-  initializeComparisonMode = -> $scope.callbacks.runMultiCompanyComparison()
-
   # ---------------------------------------------------------
   # ### Setting definition
   # ---------------------------------------------------------
@@ -87,7 +43,6 @@ module.controller('SettingAccountsListCtrl', ($scope, ImpacWidgetsSvc) ->
           w.moveAccountToAnotherList(acc,w.remainingAccounts,w.selectedAccounts,false)
         )
       stashedAccounts = angular.copy(w.remainingAccounts)
-      initializeComparisonMode() if $scope.callbacks?
       setting.isInitialized = true
 
   setting.toMetadata = ->

--- a/src/components/widgets-settings/params-checkboxes/params-checkboxes.directive.coffee
+++ b/src/components/widgets-settings/params-checkboxes/params-checkboxes.directive.coffee
@@ -12,7 +12,7 @@ module.controller('SettingParamsCheckboxesCtrl', ($scope) ->
 
   setting.toMetadata = ->
     param = {}
-    param[$scope.param] = $scope.options
+    param[$scope.param] = _.map $scope.options, (opt) -> { id: opt.id, value: opt.value }
     return param
 
   w.settings.push(setting)

--- a/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
@@ -27,7 +27,7 @@ module.controller('WidgetAccountsComparisonCtrl', ($scope, $q, ChartFormatterSvc
       id: 'compare_accounts',
       label: 'Compare matching accounts across your companies',
       value: false,
-      onChangeCallback: $scope.multiCompanyComparisonOnChange
+      onChangeCallback: $scope.updateSettings
     }]
     # updates model with saved settings
     if angular.isDefined(w.metadata.comparison_mode) && w.metadata.organization_ids? && w.metadata.organization_ids.length > 1
@@ -37,13 +37,6 @@ module.controller('WidgetAccountsComparisonCtrl', ($scope, $q, ChartFormatterSvc
 
   $scope.isMultiCompanyMode = ->
     _.result( _.find($scope.comparisonModeOptions, 'id', 'compare_accounts'), 'value')
-
-  $scope.multiCompanyComparisonOnChange = (isOnLoad=false) ->
-    $scope.updateSettings()
-
-  # moves all accounts from w.selectedAccounts to w.remainingAccounts
-  $scope.purgeSelectedAccounts = ->
-    w.clearAccounts(w.selectedAccounts, w.remainingAccounts)
 
   $scope.hasAccountsSelected = ->
     return w.selectedAccounts && w.selectedAccounts.length > 0

--- a/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
@@ -30,7 +30,7 @@ module.controller('WidgetAccountsComparisonCtrl', ($scope, $q, ChartFormatterSvc
       onChangeCallback: $scope.multiCompanyComparisonOnChange
     }]
     # updates model with saved settings
-    if angular.isDefined(w.metadata.comparison_mode) && w.metadata.organization_ids.length > 1
+    if angular.isDefined(w.metadata.comparison_mode) && w.metadata.organization_ids? && w.metadata.organization_ids.length > 1
       angular.merge $scope.comparisonModeOptions, w.metadata.comparison_mode
     # is this needed?
     $scope.movedAccount = {}

--- a/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.directive.coffee
@@ -22,42 +22,28 @@ module.controller('WidgetAccountsComparisonCtrl', ($scope, $q, ChartFormatterSvc
   # --------------------------------------
   w.initContext = ->
     $scope.isDataFound = w.content? && !_.isEmpty(w.content.complete_list)
-    # parameters for params-checkboxes.directive
+    # defines the available options for params-checkboxes.directive
     $scope.comparisonModeOptions = [{
       id: 'compare_accounts',
       label: 'Compare matching accounts across your companies',
       value: false,
       onChangeCallback: $scope.multiCompanyComparisonOnChange
     }]
+    # updates model with saved settings
     if angular.isDefined(w.metadata.comparison_mode) && w.metadata.organization_ids.length > 1
       angular.merge $scope.comparisonModeOptions, w.metadata.comparison_mode
+    # is this needed?
     $scope.movedAccount = {}
-
-  # callbacks for settings components
-  $scope.callbacks = {}
-  # applys all comparison mode params
-  $scope.callbacks.runMultiCompanyComparison = (isOnLoad=true) ->
-    _.forEach $scope.comparisonModeOptions, (option) -> option.onChangeCallback(isOnLoad)
 
   $scope.isMultiCompanyMode = ->
     _.result( _.find($scope.comparisonModeOptions, 'id', 'compare_accounts'), 'value')
 
   $scope.multiCompanyComparisonOnChange = (isOnLoad=false) ->
-    $scope.purgeSelectedAccounts() unless isOnLoad
-    if $scope.isMultiCompanyMode()
-      w.groupAccounts(w.remainingAccounts, w.remainingAccounts, 'account_name')
-    else
-      w.ungroupAccounts(w.remainingAccounts, w.remainingAccounts, 'account_name')
+    $scope.updateSettings()
 
   # moves all accounts from w.selectedAccounts to w.remainingAccounts
   $scope.purgeSelectedAccounts = ->
     w.clearAccounts(w.selectedAccounts, w.remainingAccounts)
-
-  # move selected accounts & set all comparisonModeOptions to false before updating settings.
-  $scope.beforeUpdateSettings = ->
-    $scope.purgeSelectedAccounts()
-    _.forEach $scope.comparisonModeOptions, (option) -> option.value = false if option.value
-    $scope.updateSettings()
 
   $scope.hasAccountsSelected = ->
     return w.selectedAccounts && w.selectedAccounts.length > 0

--- a/src/components/widgets/accounts-comparison/accounts-comparison.tmpl.html
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.tmpl.html
@@ -8,7 +8,7 @@
 
     <div align="right">
       <button class="btn btn-default" ng-click="initSettings()">Cancel</button>
-      <button class="btn btn-warning" ng-click="beforeUpdateSettings()">Save</button>
+      <button class="btn btn-warning" ng-click="updateSettings()">Save</button>
     </div>
   </div>
 

--- a/src/components/widgets/accounts-comparison/accounts-comparison.tmpl.html
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.tmpl.html
@@ -1,5 +1,5 @@
 <div widget-accounts-comparison>
-  <div setting-accounts-list parent-widget="widget" deferred="::accountsListDeferred" callbacks="callbacks"/>
+  <div setting-accounts-list parent-widget="widget" deferred="::accountsListDeferred"/>
 
   <div ng-show="widget.isEditMode" class="edit">
     <h4>Widget settings</h4>


### PR DESCRIPTION
Switching to and from comparison mode now triggers normal metadata update cycle, with api returning formatted accounts data. The params-checkboxes settings directive also now only converts relevant data to metadata.