### PR TITLE
Improved front-end logic for comparable and non-comparable accounts

### DIFF
--- a/src/components/widgets/accounts-comparison/accounts-comparison.less
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.less
@@ -50,4 +50,9 @@
   .settings.params-checkboxes {
     margin-left: 13px;
   }
+
+  .comparable-error h5 {
+    margin-left: 13px;
+    color: @impac-negative;
+  }
 }

--- a/src/components/widgets/accounts-comparison/accounts-comparison.tmpl.html
+++ b/src/components/widgets/accounts-comparison/accounts-comparison.tmpl.html
@@ -16,17 +16,21 @@
 
     <div ng-show="(isDataFound==true)">
       <!-- multi-companies mode -->
-      <div ng-show="widget.metadata.organization_ids.length > 1">
+      <div ng-show="widget.metadata.organization_ids.length > 1 && canSelectComparisonMode || isComparisonMode()">
         <div setting-params-checkboxes options="comparisonModeOptions" param="comparison_mode" parent-widget="widget" deferred="::paramsCheckboxesDeferred"/>
       </div>
       <!-- end -->
-      <div ng-hide="hasAccountsSelected()" class="row">
+      <div ng-hide="hasAccountsSelected() || noComparableAccounts" class="row">
         <h5>Select the accounts you wish to compare.</h5>
         <div class="col-md-6">
           <div class="input-group">
             <select ng-model="movedAccount" ng-options="account.name + ' (' + formatAmount(account) + ')' for account in widget.remainingAccounts" class="form-control" ng-show="widget.hasEditAbility" ng-change="addAccount(movedAccount)"></select>
           </div>
         </div>
+      </div>
+      <!-- error: when there are no comparable accounts matched -->
+      <div ng-show="isComparisonMode() && noComparableAccounts" class="row comparable-error">
+        <h5>No comparable accounts found.</h5>
       </div>
 
       <div ng-show="hasAccountsSelected()">
@@ -40,7 +44,7 @@
           <div class="col-md-12">
             <div class="widget-lines-container">
               <div class="widget-line" ng-repeat="account in widget.selectedAccounts track by $index">
-                <div ng-if="isMultiCompanyMode()" ng-repeat="groupedAccount in account.accounts track by $index">
+                <div ng-if="isComparisonMode()" ng-repeat="groupedAccount in account.accounts track by $index">
                   <button class="close" ng-click="removeAccount(account)" ng-show="widget.hasDeleteAbility">
                     x
                   </button>
@@ -48,7 +52,7 @@
                   <i class="fa fa-circle" style="margin: 0px 8px; color: {{getAccountColor(groupedAccount)}}" />
                   {{groupedAccount.name}}
                 </div>
-                <div ng-if="!isMultiCompanyMode()">
+                <div ng-if="!isComparisonMode()">
                   <button class="close" ng-click="removeAccount(account)" ng-show="widget.hasDeleteAbility">
                     x
                   </button>
@@ -64,7 +68,7 @@
         <div class="row">
           <div class="add-account">
             <div class="input-group">
-              <select ng-model="movedAccount" ng-options="account.name + ' (' + formatAmount(account) + ')' for account in widget.remainingAccounts track by account.uid" class="form-control" ng-show="widget.hasDeleteAbility" ng-change="addAccount(movedAccount)" ng-disabled="widget.selectedAccounts.length >= 15 || widget.remainingAccounts.length == 0 || isMultiCompanyMode()">
+              <select ng-model="movedAccount" ng-options="account.name + ' (' + formatAmount(account) + ')' for account in widget.remainingAccounts track by account.uid" class="form-control" ng-show="widget.hasDeleteAbility" ng-change="addAccount(movedAccount)" ng-disabled="widget.selectedAccounts.length >= 15 || widget.remainingAccounts.length == 0 || isComparisonMode()">
                 <option value="" disabled selected>+ ADD ACCOUNT</option>
               </select>
             </div>


### PR DESCRIPTION
- when the returned accounts data is from only one organisation, comparison mode is disabled.
- if comparison mode selection was saved and then returned accounts data is from only one organisation, an error message is displayed and the ability to deselect comparison mode is available. Once deselection is made, the comparison mode is disabled.