### PR TITLE
string matching logic for quanity selectors across widgets

### DIFF
--- a/src/components/widgets/sales-aged/sales-aged.directive.coffee
+++ b/src/components/widgets/sales-aged/sales-aged.directive.coffee
@@ -82,10 +82,10 @@ module.controller('WidgetSalesAgedCtrl', ($scope, $q, ChartFormatterSvc, $filter
         datasetFill: true,
         pointDot: true,
       }
-      angular.merge(options, {currency: 'hide'}) if $scope.filter.value=='quantity_sold'
+      angular.merge(options, {currency: 'hide'}) if $scope.filter.value.indexOf('quantity') > -1
 
       chartData = ChartFormatterSvc.lineChart(inputData,options)
-      
+
       # calls chart.draw()
       $scope.drawTrigger.notify(chartData)
 

--- a/src/components/widgets/sales-comparison/sales-comparison.directive.coffee
+++ b/src/components/widgets/sales-comparison/sales-comparison.directive.coffee
@@ -171,10 +171,10 @@ module.controller('WidgetSalesComparisonCtrl', ($scope, $q, $filter, ChartFormat
         datasetFill: false,
         pointDot: false,
       }
-      angular.merge(options, {currency: 'hide'}) if $scope.filter.value=='quantity_sold'
+      angular.merge(options, {currency: 'hide'}) if $scope.filter.value.indexOf('quantity') > -1
 
       chartData = ChartFormatterSvc.lineChart(inputData,options)
-      
+
       # calls chart.draw()
       $scope.drawTrigger.notify(chartData)
 

--- a/src/components/widgets/sales-growth/sales-growth.directive.coffee
+++ b/src/components/widgets/sales-growth/sales-growth.directive.coffee
@@ -75,9 +75,9 @@ module.controller('WidgetSalesGrowthCtrl', ($scope, $q, ChartFormatterSvc) ->
         scaleBeginAtZero: all_values_are_positive,
         showXLabels: false,
       }
-      angular.merge(options, {currency: 'hide'}) if $scope.filter.value=='quantity_sold'
+      angular.merge(options, {currency: 'hide'}) if $scope.filter.value.indexOf('quantity') > -1
       chartData = ChartFormatterSvc.lineChart([inputData],options)
-      
+
       # calls chart.draw()
       $scope.drawTrigger.notify(chartData)
 

--- a/src/components/widgets/sales-summary/sales-summary.directive.coffee
+++ b/src/components/widgets/sales-summary/sales-summary.directive.coffee
@@ -76,7 +76,7 @@ module.controller('WidgetSalesSummaryCtrl', ($scope, $q, ChartFormatterSvc) ->
         percentageInnerCutout: 50,
         tooltipFontSize: 12,
       }
-      angular.merge(pieOptions, {currency: 'hide'}) if $scope.filter.value.toLowerCase().indexOf('quantity') >= 0
+      angular.merge(pieOptions, {currency: 'hide'}) if $scope.filter.value.indexOf('quantity') > -1
       chartData = ChartFormatterSvc.pieChart(pieData, pieOptions)
 
       # calls chart.draw()


### PR DESCRIPTION
Fixes integer values displaying as currency across widgets, and prevents having to manually add matchers when extending widget filters to-do with quantity.

@cesar-tonnoir 