### PR TITLE
improvements to elements displayed 

### DIFF
--- a/src/components/dashboard-selector/bootstrap-tabs.tmpl.html
+++ b/src/components/dashboard-selector/bootstrap-tabs.tmpl.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="buttons-bar col-md-8">
+  <div class="buttons-bar col-md-8" ng-show="isThereADashboard()">
     <tabset type="{{selectorType}}">
       <tab ng-repeat="dhb in dashboardsList" ng-click="selectDashboard(dhb.id)" active="dhb.active">
         <tab-heading>

--- a/src/components/dashboard/dashboard.tmpl.html
+++ b/src/components/dashboard/dashboard.tmpl.html
@@ -82,8 +82,12 @@
   </div>
 
   <!-- custom widget selector template configured from ImpacThemingProvider -->
-  <div id="custom-widget-selector" ng-if="customWidgetSelector.path" ng-include="customWidgetSelector.path"></div>
+  <div id="custom-widget-selector" ng-if="customWidgetSelector.path" ng-include="customWidgetSelector.path" ng-hide="showChooseDhbMsg()"></div>
 
+  <!-- currency selector -->
+  <div id="dashboard-settings" ng-hide="showChooseDhbMsg()">
+    <div ng-hide="showChooseDhbMsg()" dashboard-setting-currency currency="currentDhb.currency" />
+  </div>
 
   <!-- Errors -->
   <div class="alert alert-error" ng-show="errors">
@@ -147,7 +151,7 @@
   </div>
 
   <!-- Widgets -->
-  <div class='row' id="widgets-section">
+  <div class='row' id="widgets-section" ng-hide="showNoWidgetsMsg() || showChooseDhbMsg()">
     <div id="widgets-container" ui-sortable="sortableOptions" ng-model="currentDhb.widgets">
       <div impac-widget widget="widget" is-accessibility="accessibility" parent-dashboard="currentDhb" ng-repeat="widget in currentDhb.widgets" class="widget-item" ng-class="widget.getColClass()" on-display-alerts="displaySubMenu()" />
       <!-- Add Widget Tile, enabled & customised in ImpacThemingProvider -->

--- a/src/components/widgets/hr-payroll-summary/hr-payroll-summary.less
+++ b/src/components/widgets/hr-payroll-summary/hr-payroll-summary.less
@@ -3,4 +3,9 @@
   .right-panel .widget-lines-container {
       max-height: 175px;
   }
+  .no-element p {
+    // corrects alignment issues with the container, which caused text to overflow beyond parents.
+    max-width: 90% !important;
+    margin: auto !important;
+  }
 }

--- a/src/components/widgets/hr-payroll-summary/hr-payroll-summary.tmpl.html
+++ b/src/components/widgets/hr-payroll-summary/hr-payroll-summary.tmpl.html
@@ -96,7 +96,7 @@
         </div>
 
         <div ng-hide="hasElements()" class="no-element">
-          Select one or several employee(s) or category(ies) to display the corresponding summary
+          <p>Select one or several employee(s) or category(ies) to display the corresponding summary</p>
         </div>
 
       </div>


### PR DESCRIPTION
- Tabs bar is hidden if there is no dashboard (click "create dashboard" button)
- Custom widget selector's are hidden when there is noDashboardMsg is showing (click "create dashboard" button)
- widgets section is hidden when noWidgets or noDashboards message is showing

@cesar-tonnoir not ready for merge yet, may batch more changes into this PR. 

** These changes are tested on mnoe & mno.