### PR TITLE
feat: workspace cred's alert & dhb load fail handling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "Chart.js": "2.0.0-beta",
     "lodash": "~3.10.1",
     "components-font-awesome": "~4.5.0",
-    "angular-poller": "~0.4.2"
+    "angular-poller": "~0.4.2",
+    "angular-toastr": "^1.7.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.0",

--- a/src/components/dashboard/dashboard.directive.coffee
+++ b/src/components/dashboard/dashboard.directive.coffee
@@ -63,11 +63,14 @@ module.controller('ImpacDashboardCtrl', ($scope, $http, $q, $filter, $modal, $lo
     # reload the <impac-dashboards> on organization change.
     # In other apps, calling this method should be enough to force a complete reload on Impac! contents
     $scope.isLoading = true
+    $scope.failedDashboardLoad = false
     ImpacDashboardsSvc.load(true).then(
       (success) ->
         $scope.activateTimer()
         $scope.hasMyobEssentialsOnly = ImpacMainSvc.config.currentOrganization.has_myob_essentials_only
       (error) ->
+        # on dashboard failed first load, user should not be able to access dashboard controls.
+        $scope.failedDashboardLoad = true
         $scope.isLoading=false
     )
 

--- a/src/components/dashboard/dashboard.less
+++ b/src/components/dashboard/dashboard.less
@@ -274,6 +274,11 @@
   }
 }
 
+// dashboard failed to load message.
+.analytics.load-failed p {
+  font-size: 22px;
+}
+
 // Tooltips are append to body
 .tooltip.impac-widget-selector-tooltip .tooltip-inner.ng-binding {
   font-size: 14px;
@@ -297,3 +302,4 @@
 .modal-footer .loader {
   .loader-style(@impac-dashboard-loading-spinner)
 }
+

--- a/src/components/dashboard/dashboard.tmpl.html
+++ b/src/components/dashboard/dashboard.tmpl.html
@@ -1,5 +1,5 @@
 <!-- DASHBOARD -->
-<div class="analytics" ng-hide="(isLoading || forceLoad)" ng-class="{'hide-dhb': (isLoading || forceLoad), 'show-dhb': !(isLoading || forceLoad)}">
+<div class="analytics" ng-hide="(isLoading || forceLoad || failedDashboardLoad)" ng-class="{'hide-dhb': (isLoading || forceLoad), 'show-dhb': !(isLoading || forceLoad)}">
   <div mno-star-wizard=true modal-open='starWizardModal.value'></div>
 
   <!-- Title and Dashboard selection -->
@@ -177,6 +177,14 @@
   <div class="row">
     <div class="col-md-12 loader-container text-center" style="margin-top: 200px;">
       <i class="fa fa-refresh fa-spin" style="font-size: 250px; opacity: 0.7;"/>
+    </div>
+  </div>
+</div>
+
+<div class="analytics load-failed" ng-show="failedDashboardLoad">
+  <div class="row">
+    <div class="col-md-12 text-center" style="margin-top: 200px;">
+      <p>Oops, failed to load Impac Angular...</p>
     </div>
   </div>
 </div>

--- a/src/services/main/main.svc.coffee
+++ b/src/services/main/main.svc.coffee
@@ -49,7 +49,7 @@ angular
           deferred.resolve(_self.config)
 
         ,(error) ->
-          $log.error("ImpacMainSvc: cannot set organization: #{id} as currentOrganization")
+          $log.error("ImpacMainSvc: cannot load organizations")
           deferred.reject(error)
 
       else
@@ -66,7 +66,7 @@ angular
       else
         _self.config.currentOrganization = {}
         $log.error("ImpacMainSvc: cannot set default current organization")
-        return {error: {code: 400, message: "cannot set default current organization"}} 
+        return {error: {code: 400, message: "cannot set default current organization"}}
 
     @setCurrentOrganization = (id=null) ->
       if id?

--- a/workspace/index.html
+++ b/workspace/index.html
@@ -6,6 +6,7 @@
   <!-- bower:css -->
   <link rel="stylesheet" href="../bower_components/angular-xeditable/dist/css/xeditable.css" />
   <link rel="stylesheet" href="../bower_components/components-font-awesome/css/font-awesome.css" />
+  <link rel="stylesheet" href="../bower_components/angular-toastr/dist/angular-toastr.css" />
   <!-- endbower -->
   <link href='https://fonts.googleapis.com/css?family=Share+Tech+Mono' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="../dist/impac-angular.css">
@@ -41,6 +42,7 @@
   <script src="../bower_components/Chart.js/Chart.js"></script>
   <script src="../bower_components/lodash/lodash.js"></script>
   <script src="../bower_components/angular-poller/angular-poller.min.js"></script>
+  <script src="../bower_components/angular-toastr/dist/angular-toastr.tpls.js"></script>
   <!-- endbower -->
 
   <script src="index.js"></script>

--- a/workspace/index.js
+++ b/workspace/index.js
@@ -1,7 +1,7 @@
-var module = angular.module('impacWorkspace', ['maestrano.impac']);
+var module = angular.module('impacWorkspace', ['maestrano.impac', 'toastr']);
 
 // Configuration impac-angular lib on module impacWorkSpace run.
-module.run(function ($log, $window, $q, $http, ImpacLinking, ImpacRoutes, ImpacTheming, ImpacDeveloper) {
+module.run(function ($log, $window, $q, $http, ImpacLinking, ImpacRoutes, ImpacTheming, ImpacDeveloper, toastr) {
 
   //--------------------------------------------------------
   // Start editing
@@ -45,7 +45,7 @@ module.run(function ($log, $window, $q, $http, ImpacLinking, ImpacRoutes, ImpacT
   //--------------------------------------------------------
   // Check credentials have been provided
   if (!settings.api_key || !settings.api_secret) {
-    fail('missing authentication credentials!');
+    fail('Missing authentication credentials!');
   }
 
   // Impac-angular configurations.
@@ -95,14 +95,16 @@ module.run(function ($log, $window, $q, $http, ImpacLinking, ImpacRoutes, ImpacT
       .then(function (response) {
         var organizations = (response.data || []);
         return { organizations: organizations, currentOrgId: (organizations[0].id || null) };
-      },
-        fail
-      );
+      }, function () {
+        var msg = 'Unable to retrieve Organizations';
+        fail(msg);
+        return $q.reject(msg);
+      });
   }
 
-  function fail(err) {
-    $log.error('workspace/index.js ERROR: ', err);
-    return {};
+  function fail(msg) {
+    $log.error('workspace/index.js Error: ' + msg);
+    toastr.error(msg, 'Error');
   }
 
 });


### PR DESCRIPTION
- added toastr bower dep for alerts
- toastr alerts for errors requiring api credentials & loading organizations
- workspace errors now properly reject promises to stop endless load
- new dashboard.tmpl.html screen for displayed failed dhb load message
  - hides dashboards controls which would otherwise still be visible.

@cesar-tonnoir please review