### PR TITLE
[IMPAC-175] [IMPAC-286] Kpis selector

### DIFF
--- a/src/components/kpi/kpi.less
+++ b/src/components/kpi/kpi.less
@@ -1,4 +1,4 @@
-impac-kpi .kpi {
+.analytics .impac-kpi .kpi {
   position: relative;
   max-width: 220px;
   min-height: @kpi-max-height;
@@ -13,8 +13,29 @@ impac-kpi .kpi {
     margin-right: auto;
   }
 
-  &.triggered {
+  &.triggered, &.add:hover {
     border-bottom: @kpi-triggered-border-bottom;
+  }
+
+  &.add {
+    .kpi-text {
+      .emphasis { visibility: hidden; }
+    }
+  }
+
+  &.add:hover {
+    cursor: pointer;
+    .top-line { background-color: @kpi-top-line-triggered-background-color; }
+    .kpi-text {
+      color: @kpi-text-triggered-color;
+      .emphasis { visibility: visible; }
+    }
+    .kpi-icon {
+      color: @kpi-icon-triggered-color;
+      .fa-plus:before {
+        content: "\f00c";
+      }
+    }
   }
 
   &.editing {

--- a/src/components/kpis-bar/kpis-bar.less
+++ b/src/components/kpis-bar/kpis-bar.less
@@ -6,6 +6,8 @@
   background-color: @kpis-bar-background-color;
   box-shadow: @kpis-bar-box-shadow;
 
+  &.empty { min-height: 50px; }
+
   transition: all .2s ease-in;
   @media screen and (min-width: 725px) {
     padding: 0 60px;
@@ -14,46 +16,12 @@
     margin-top: 18px;
   }
 
-  impac-kpi {
+  .impac-kpi {
     .column-gutter(5px);
 
     @media screen and (min-width: 1200px) {
       padding-left: 20px;
       padding-right: 20px;
-    }
-  }
-
-  .available-kpis-container {
-    text-align: left;
-    position: absolute;
-    z-index: 15;
-    background-color: @impac-widget-background-color;
-    width: 500px;
-    max-height: 115px;
-    box-shadow: 0px 3px 12px -4px;
-
-    .scrollable();
-
-    .available-kpi {
-      border-bottom: solid 1px #D8DBDB;
-      padding: 4px;
-      padding-left: 8px;
-      height: 38px;
-
-      span.kpi-name {
-        padding-top: 5px;
-        display: inline-block;
-      }
-
-      .form-control-static, .btn.btn-sm.btn-info {
-        float: right;
-        min-height: 30px;
-        height: 30px;
-        float: right;
-        margin-left: 3px;
-        margin-top: 0px;
-        font-weight: bold;
-      }
     }
   }
 
@@ -75,9 +43,10 @@
       font-size: 18px;
       transition: all 0.28s ease-in;
       &.im-primary {
-        background: @purple;
-        &:hover {
-          background: darken(@purple, 10%);
+        background: #4c4749;
+        &.disabled { background: #b2b5c1; }
+        &:hover:not(.disabled) {
+          background: black;
         }
       }
     }
@@ -104,6 +73,26 @@
     }
   }
 
+  .title {
+    .text-center {
+      line-height: 3;
+      font-variant: small-caps;
+      font-size: larger;
+    }
+    .badge {
+      position: absolute;
+      top: 8px;
+      left: -10px;
+      background-color: #d1e55c;
+      color: #4f5959;
+      box-shadow: 0px 1px 3px -1px;
+    }
+  }
+
+  .add-bar {
+    border-bottom: dashed 1px;
+  }
+
   .kpi-loader {
     display: flex;
     align-items: center;
@@ -117,3 +106,5 @@
   // color: @light-black;
   padding: 5px 0px;
 }
+
+.analytics.pdf-mode kpis-bar > .kpis .title-actions { display: none; }

--- a/src/components/kpis-bar/kpis-bar.tmpl.html
+++ b/src/components/kpis-bar/kpis-bar.tmpl.html
@@ -1,28 +1,52 @@
-<div class="kpis">
-  <div class="title-actions">
+<div class="kpis" ng-class="{'empty': (kpis.length == 0), 'hidden-print': (kpis.length == 0)}">
 
-    <button type="button" class="add-kpis im-fab im-primary" ng-click="toggleAvailableKpis()">
-      <a href=""><i class="fa fa-plus"></i></a>
+  <div class="title-actions">
+    <button type="button" class="add-kpis im-fab im-primary" ng-click="(availableKpis.list.length > 0) && availableKpis.toggle()" ng-class="{disabled: (availableKpis.list.length == 0)}">
+      <a href=""><i class="fa" ng-class="{'fa-plus': availableKpis.hide, 'fa-minus': !availableKpis.hide}"></i></a>
     </button>
-    <button type="button" class="edit-kpis im-fab im-primary" ng-click="toggleEditMode()">
+    <button type="button" class="edit-kpis im-fab im-primary" ng-click="toggleEditMode()" ng-if="kpis.length > 0">
       <a href=""><i class="fa fa-cog"></i></a>
     </button>
+  </div>
 
-    <div class="available-kpis-container" collapse="hideAvailableKpis">
-      <div ng-repeat="kpi in availableKpis track by $index" class="available-kpi" ng-init="kpi.element_watched = kpi.watchables[0]">
-        <span class="kpi-name">{{kpi.name}}</span>
-        <button class="btn btn-sm btn-info" ng-click="addKpi(kpi)">+ Attach</button>
-        <!-- <select class="form-control-static input-sm" ng-model="kpi.element_watched" ng-options="watchable for watchable in kpi.watchables"></select> -->
+  <div class="row title" ng-if="kpis.length == 0 && availableKpis.hide">
+    <span class="badge">New!</span>
+    <div class="col-xs-12 text-center">
+      <a href="#" ng-click='availableKpis.toggle()'>
+        You can now attach KPIs to your dashboard
+      </a>
+    </div>
+  </div>
+
+  <div class="row add-bar" collapse="availableKpis.hide">
+    <div class="col-xs-12 col-sm-12">
+      <div class="row">
+        <div ng-repeat="kpi in availableKpis.list track by $index" class="impac-kpi col-xs-6 col-sm-4 col-md-3" ng-click="addKpi(kpi)" ng-init="kpi.element_watched = kpi.watchables[0]">
+          <div class="kpi add" ng-hide="isAddingKpi">
+            <div class="top-line ui-sortable-handle"></div>
+            <div class="kpi-content">
+              <div class="kpi-show row nomargin nopadding">
+                <div class="col-xs-3 col-sm-3 kpi-icon">
+                  <i class="fa fa-2x fa-plus"></i>
+                </div>
+                <div class="col-xs-9 col-sm-9 kpi-text">
+                  <span class="caption"><strong>{{kpi.name}}</strong></span>
+                  <span class="emphasis">Add to dashboard</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-
   </div>
+
   <div class="row">
     <div class="col-xs-12 col-sm-12">
       <div class="row">
         <div ui-sortable="sortableOptions" ng-model="kpis">
           <div ng-repeat="kpi in kpis track by kpi.id">
-            <impac-kpi class="col-xs-6 col-sm-4 col-md-3" kpi="kpi" on-delete="removeKpi(kpi.id)" edit-mode="showEditMode" kpi-edit-settings="kpisEditSettings[kpi.id]" available-kpis="availableKpis" />
+            <div impac-kpi class="impac-kpi col-xs-6 col-sm-4 col-md-3" kpi="kpi" on-delete="removeKpi(kpi.id)" edit-mode="showEditMode" kpi-edit-settings="kpisEditSettings[kpi.id]" available-kpis="availableKpis.list" />
           </div>
         </div>
         <div ng-show="isAddingKPI" class="col-xs-6 col-sm-4 col-md-3 kpi-loader">


### PR DESCRIPTION
@xaun can you please review?

Status update - still a few things to fix:
- remove account name from kpi attached to widget
- discovery endpoint wasn't working on mine?..
- saving the kpis when on edit mode is not obvious
- alerting modal should take all the watchables into account
- API to return dynamic edit captions
- API to return appropriate emphasis for all the existing kpis
- kpis bar's `kpisEditSettings` is buggy: settings are not removed when the kpi is removed from `$scope.kpis` -> couldn't the edit settings be saved in the kpi object (in $scope.kpis)
- bug spotted (not appearing 100% of the time): when I try to attach a kpi "too fast", I receive a 400 because the element_watched cannot be blank. Probably a problem with the ng-init: we should attach the element_watched to the object directly in the service when we retrieve the list of the available kpis (until we implement a better logic)
- metadata hist_parameters is incorrect (we should add at least a dates-picker to let the user select the time range)