### PR TITLE
[IMPAC - 307] - Added an automatic version generator

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -3,6 +3,14 @@
 var path = require('path');
 var gulp = require('gulp');
 var conf = require('./conf');
+var pkg = require('../bower.json');
+var banner = ['/**',
+  ' * <%= pkg.name %> - <%= pkg.description %>',
+  ' * @version v<%= pkg.version %>',
+  ' * @git <%= pkg.repository.url %>',
+  ' * @license <%= pkg.license %>',
+  ' */',
+  ''].join('\n');
 
 var $ = require('gulp-load-plugins')({
   pattern: ['gulp-*', 'del']
@@ -47,8 +55,8 @@ gulp.task('clean', function (asyncCallback) {
   return $.del([path.join(conf.paths.dist, '/'), path.join(conf.paths.tmp, '/')], asyncCallback);
 });
 
-gulp.task('build', ['scripts', 'styles', 'partials'], function() {
-  // Source files for final dist build - NOTE: order is imporant.
+gulp.task('build', ['version', 'scripts', 'styles', 'partials'], function() {
+  // Source files for final dist build - NOTE: order is important.
   var buildSourceFiles = [
     path.join(conf.paths.src, 'impac-angular.prefix'),
     path.join(conf.paths.src, 'impac-angular.module.js'),
@@ -56,7 +64,7 @@ gulp.task('build', ['scripts', 'styles', 'partials'], function() {
     path.join(conf.paths.src, 'impac-angular.suffix'),
     path.join(conf.paths.tmp, 'scripts/**/*.js'),
     path.join(conf.paths.lib, '*.js'),
-    path.join(conf.paths.dist, 'impac-angular.css'),
+    path.join(conf.paths.dist, 'impac-angular.css')
   ];
 
   var jsFilter = $.filter(['**/*', '!**/*.css'], { restore: true });
@@ -68,12 +76,14 @@ gulp.task('build', ['scripts', 'styles', 'partials'], function() {
     // .pipe($.sourcemaps.init())
     // .pipe($.sourcemaps.write())
     .pipe($.concat('impac-angular.js'))
+    .pipe($.header(banner, { pkg: pkg } ))  // Add details about the current version
     .pipe($.ngAnnotate())
     .pipe(gulp.dest(conf.paths.dist)) // Output impac-angular.js
     .pipe($.size({ title: path.join(conf.paths.dist, '/'), showFiles: true }))
     .pipe($.ngAnnotate())
     .pipe($.uglify()).on('error', conf.errorHandler('Uglify'))
     .pipe($.rename('impac-angular.min.js'))
+    .pipe($.header(banner, { pkg: pkg } ))  // Add details about the current version
     .pipe(jsFilter.restore)
     .pipe(cssFilter)
     .pipe($.minifyCss({ processImport: false, compatibility: 'ie8' }))

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -1,8 +1,11 @@
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
 var gulp = require('gulp');
+
 var conf = require('./conf');
+var bowerVersion = require('../bower.json').version;
 
 var $ = require('gulp-load-plugins')();
 
@@ -16,5 +19,12 @@ gulp.task('scripts', function () {
     // .pipe($.coffeelint.reporter())
     .pipe($.coffee()).on('error', conf.errorHandler('CoffeeScript'))
     .pipe(gulp.dest(path.join(conf.paths.tmp, '/scripts')))
-    .pipe($.size());
+    .pipe($.size())
 });
+
+// Scripts to run impac.version in the console (need to refresh first)
+// Needs to be called AFTER scripts due to permissions errors
+gulp.task('version', ['scripts'], function () {
+  return fs.writeFileSync(path.join(conf.paths.tmp, '/scripts', '/version.js'), '(function (module) {module["impac"] = {"version":"' + bowerVersion + '"};}).call(window, window, window["impac"]);\n');
+});
+

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -5,7 +5,7 @@ var path = require('path');
 var gulp = require('gulp');
 
 var conf = require('./conf');
-var bowerVersion = require('../bower.json').version;
+var bowerInfo = require('../bower.json');
 
 var $ = require('gulp-load-plugins')();
 
@@ -25,6 +25,8 @@ gulp.task('scripts', function () {
 // Scripts to run impac.version in the console (need to refresh first)
 // Needs to be called AFTER scripts due to permissions errors
 gulp.task('version', ['scripts'], function () {
-  return fs.writeFileSync(path.join(conf.paths.tmp, '/scripts', '/version.js'), '(function (module) {module["impac"] = {"version":"' + bowerVersion + '"};}).call(window, window, window["impac"]);\n');
+  var func = '(function () {console.info("' + bowerInfo.description + ' - v' + bowerInfo.version + '"); window["impac"] = {"version": "' + bowerInfo.version + '"};}).call();';
+
+  return fs.writeFileSync(path.join(conf.paths.tmp, '/scripts', '/version.js'), func);
 });
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-coffeelint": "^0.5.0",
     "gulp-concat": "^2.3.4",
     "gulp-filter": "^3.0.1",
+    "gulp-header": "^1.8.7",
     "gulp-inject": "^1.5.0",
     "gulp-less": "^3.0.3",
     "gulp-load-plugins": "^1.0.0",


### PR DESCRIPTION
I added a header for both impac-angular.js and impac-angular.min.js files produced by gulp giving some details about the module (version, name, license...). This is taken from the bower.json file.

Also added a clumsy version module that can be called from the console.
`impac.version`
returning whatever version number is in the bower.json file
`1.3.9`

**Bug:** In order to work, the page needs to be refreshed at least once before the above command works.