### PR TITLE
Adds a dhb.svc callback for triggered dhb loader spinner

### DIFF
--- a/src/components/dashboard/dashboard.directive.coffee
+++ b/src/components/dashboard/dashboard.directive.coffee
@@ -71,7 +71,11 @@ module.controller('ImpacDashboardCtrl', ($scope, $http, $q, $filter, $modal, $lo
       (error) ->
         # on dashboard failed first load, user should not be able to access dashboard controls.
         $scope.failedDashboardLoad = true
-        $scope.isLoading=false
+        $scope.isLoading = false
+    )
+
+    ImpacDashboardsSvc.dhbLoader().then(null, null, (triggerLoad)->
+      if triggerLoad then $scope.isLoading = true else $scope.activateTimer()
     )
 
     $scope.activateTimer = ->
@@ -431,7 +435,7 @@ module.directive('impacDashboard', ($templateCache, ImpacDashboardsSvc) ->
       },
       template: $templateCache.get('dashboard/dashboard.tmpl.html'),
       controller: 'ImpacDashboardCtrl'
-      
+
       link: (scope, element) ->
         scope.pdfMode = false
         ImpacDashboardsSvc.pdfModeEnabled().then(null, null, ->

--- a/src/services/dashboards/dashboards.spec.js
+++ b/src/services/dashboards/dashboards.spec.js
@@ -40,7 +40,7 @@ describe('<> ImpacDashboardsSvc', function () {
   // Callbacks
   // -------------------------------------------------
   it('defines some callbacks', function() {
-    expect(Object.keys(svc.callbacks).length).toEqual(5);
+    expect(Object.keys(svc.callbacks).length).toEqual(6);
     expect(typeof svc.callbacks.dashboardChanged.$$state).toBeDefined();
     expect(typeof svc.callbacks.widgetAdded.$$state).toBeDefined();
   });

--- a/src/services/dashboards/dashboards.svc.coffee
+++ b/src/services/dashboards/dashboards.svc.coffee
@@ -53,6 +53,11 @@ angular
     @tick = ->
       _self.callbacks.ticked.notify()
 
+    @callbacks.dhbLoader = $q.defer()
+    @dhbLoader = ->
+      return _self.callbacks.dhbLoader.promise
+    @triggerDhbLoader = (bool=false)->
+      _self.callbacks.dhbLoader.notify(bool)
 
     #====================================
     # Context helpers (return booleans: can be called but can't be bound!)

--- a/src/services/dashboards/dashboards.svc.coffee
+++ b/src/services/dashboards/dashboards.svc.coffee
@@ -83,6 +83,19 @@ angular
     # Loaders and setters
     #====================================
 
+    # Method used for reloading an already loaded dashboard, will reload it properly
+    # while also triggering the dhbLoader spinner.
+    @reload = (force=false) ->
+      deferred = $q.defer()
+      _self.triggerDhbLoader(true)
+      _self.load(force).then(
+        -> deferred.resolve()
+        -> deferred.reject()
+      ).finally(->
+        _self.triggerDhbLoader(false)
+      )
+      return deferred.promise
+
     @loadLocked=false
     @load = (force=false) ->
       deferred = $q.defer()


### PR DESCRIPTION
This exposes the ability for parent applications to trigger a dashboard spinner
loader (e.g mnoe-demo on organization selection). This improves the transition by
hiding the doms re-binding of the widget ng-repeat choppyness.

@alexnoox @cesar-tonnoir please review