### PR TITLE
Fix image paths for default images

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,23 +114,29 @@ _usage_: Retrieving organizations and current organization id.
 
 #### Impac Assets Provider (assets.svc.coffee)
 
-Provides impac-angular with paths for custom static assets hosted by the parent application. Note Impac Angular will provide defaults for these.
+Provides impac-angular with paths for custom images hosted by the parent application. The Impac Angular library will provide default images for these, although you must configure the `defaultImagesPath` accordly to the parent apps project structure. 
+Assets within `bower_components` are not publically accessible by browsers, so for this you will need a gulp/grunt/whatever task to build `bower_components` images into places like `/public/images`, or `dist/images`, or maybe the default `defaultImagesPath` of `/images` will work in your parent app.
 
 ##### options
 **dataNotFound**<br>
 _type_: String<br>
 _default_: `''`<br>
-_usage_: Relative path to a directive containing screenshots that are displayed as a background-image for widgets when the "data not found" case is met. The files in this directory need to be organised & named to match the widget engine path. See [Impac! API docs](http://maestrano.github.io/impac/), go to a widget and look at the **engine** value (e.g `accounts/accounting_values/turnover`).
+_usage_: Relative path to a directory containing screenshots that are displayed as a background-image for widgets when the "data not found" case is met. The files in this directory need to be organised & named to match the widget engine path. See [Impac! API docs](http://maestrano.github.io/impac/), go to a widget and look at the **engine** value (e.g `accounts/accounting_values/turnover`). You don't have to provide all images, you could provide images for some select widgets, impac-angular will display the default image if a custom one is not found.
+
+**defaultImagesPath**<br>
+_type_: String<br>
+_default_: `'/images'`<br>
+_usage_: Path where impac-angular's provided images are being stored so the browser can access them in the parent app. 
 
 **impacTitleLogo**<br>
 _type_: String<br>
-_default_: `'dist/images/impac-title-logo.png'`<br>
-_usage_: Relative image path to the title logo
+_default_: `'/images/impac-title-logo.png'`<br>
+_usage_: Relative image path to a custom branding title logo, which is displayed above the dashboard. The default will be an impac title logo.
 
 **impacDashboardBackground**<br>
 _type_: String<br>
-_default_: `'dist/images/impac-dashboard-background.png'`<br>
-_usage_: Relative image path to default dashboard background
+_default_: `'/images/impac-dashboard-background.png'`<br>
+_usage_: Relative image path to a custom dashboard background image, which is displayed when the user has no dashboard or no widgets. The default will display a image of a demo dashboard in Maestrano branding / theming.
 
 ##### Example
 
@@ -142,6 +148,9 @@ angular
     paths =
       # Directory with your custom widget data not found images (which must be named accordingly).
       dataNotFound: 'images/impac/data_not_found',
+      # Maybe you want to build your lib images inside folder, 
+      defaultImagesPath: 'dashboard/images',
+      # Path to a custom image you want to provide impac angular with.
       impacTitleLogo: 'images/impac/your-impac-title-logo.png'
 
     ImpacAssetsProvider.configure(paths)

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "version": "1.3.13",
   "main": [
     "dist/impac-angular.js",
-    "dist/impac-angular.less"
+    "dist/impac-angular.less",
+    "dist/images/**/*"
   ],
   "ignore": [
     "test",

--- a/src/components/widgets-common/data-not-found/data-not-found.directive.coffee
+++ b/src/components/widgets-common/data-not-found/data-not-found.directive.coffee
@@ -18,11 +18,12 @@ module.directive('commonDataNotFound', ($templateCache, $log, $http, ImpacAssets
       image.onerror = ->
         missingImageLocationMsg = if usingDefaults then 'library defaults' else scope.widgetEngine
         $log.warn("Missing data-not-found image for #{missingImageLocationMsg}")
+
         image.remove() if image?
 
       displayDefaultImage = ->
         usingDefaults = true
-        imagePath = 'dist/images/widget-bg-width-' + scope.widgetWidth + '.png'
+        imagePath = ImpacAssets.get('defaultImagesPath') + '/widget-bg-width-' + scope.widgetWidth + '.png'
         image.src = imagePath
 
       # When providing custom images

--- a/src/services/assets/assets.svc.coffee
+++ b/src/services/assets/assets.svc.coffee
@@ -6,17 +6,22 @@ angular
     #=======================================
     # Private Defaults
     #=======================================
-    # parent app should host images, configure this provider to provide relative img paths.
+    # Parent apps can provide custom images, or use the default images by providing
+    # a defaultImagesPath of which is the parent apps responsibility to make publically available.
+    # See the README.md for more information on this.
     paths =
-      dataNotFound: '',
-      impacTitleLogo: 'dist/images/impac-title-logo.png',
-      impacDashboardBackground: 'dist/images/impac-dashboard-background.png',
+      dataNotFound: ''
+      defaultImagesPath: '/images'
+      impacTitleLogo: ':default/impac-title-logo.png'
+      impacDashboardBackground: ':default/impac-dashboard-background.png'
 
     #=======================================
     # Public methods available in config
     #=======================================
     provider.configure = (configOptions) ->
       angular.extend(paths, configOptions)
+      # For images with impac-angular defaults, inject the provided default images path.
+      _.forIn(paths, (v, k)-> paths[k] = v.replace(':default', paths.defaultImagesPath))
 
     #=======================================
     _$get = ($log) ->

--- a/workspace/index.js
+++ b/workspace/index.js
@@ -100,6 +100,11 @@ module.run(function ($log, $q, $http, ImpacLinking, ImpacAssets, ImpacRoutes, Im
     }
   });
 
+  // Link Impac! Assets
+  ImpacAssets.configure({
+    defaultImagesPath: '/dist/images',
+  })
+
   // Configure the ImpacDeveloper service options.
   ImpacDeveloper.configure({
     status: true,


### PR DESCRIPTION
Assets in bower_componets are not publically accessible by the browser.

The parent app must add a gulp task to abstract all the relevant bower_components
assets and build them into a dist/ or public/ folder. Impac Angular need to be
provided with this default images path.

