### PR TITLE
Fix/485 drill down params for 1.5.0-rc4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 #### Adds
 
 #### Fixes
+- [IMPAC-485] Fix drill down widget selection params
 
 -------------------------------------------------------------
 

--- a/src/components/widgets/accounts-cash-summary/accounts-cash-summary.directive.coffee
+++ b/src/components/widgets/accounts-cash-summary/accounts-cash-summary.directive.coffee
@@ -31,13 +31,15 @@ module.controller('WidgetAccountsCashSummaryCtrl', ($scope, $q, ChartFormatterSv
       $scope.unCollapsed = w.metadata.unCollapsed || []
 
       if w.metadata.selectedElement
+        # Attempt to find the selectedElement by statement name
         $scope.selectedElement = _.find(w.content.summary, (statement)->
-          statement.name == w.metadata.selectedElement.name
+          statement.name == w.metadata.selectedElement
         )
         if !$scope.selectedElement
+          # Attempt to find the selectedElement by statement account id
           angular.forEach(w.content.summary, (statement) ->
             $scope.selectedElement ||= _.find(statement.accounts, (account)->
-              account.id == w.metadata.selectedElement.id
+              account.id == w.metadata.selectedElement
             ) if statement.accounts?
           )
       sortData()
@@ -195,7 +197,9 @@ module.controller('WidgetAccountsCashSummaryCtrl', ($scope, $q, ChartFormatterSv
     selectedElementSetting.initialized = true
 
   selectedElementSetting.toMetadata = ->
-    {selectedElement: $scope.selectedElement}
+    return {selectedElement: null} unless $scope.selectedElement?
+    {selectedElement: $scope.selectedElement.id || $scope.selectedElement.name }
+
 
   w.settings.push(selectedElementSetting)
 

--- a/src/components/widgets/accounts-profit-and-loss/accounts-profit-and-loss.directive.coffee
+++ b/src/components/widgets/accounts-profit-and-loss/accounts-profit-and-loss.directive.coffee
@@ -59,12 +59,14 @@ module.controller('WidgetAccountsProfitAndLossCtrl', ($scope, $q, ChartFormatter
         $scope.selectedElements = []
 
         for sElem in w.metadata.selectedElements
-          foundElem = _.find(w.content.summary, (statement) -> statement.name == sElem.name )
+          # Attempt to find element by statement name
+          foundElem = _.find(w.content.summary, (statement) -> statement.name == sElem)
 
           unless foundElem
             for statement in w.content.summary
               if statement.accounts?
-                foundElem ||= _.find(statement.accounts, (account) -> sElem.account_id == account.account_id )
+                # Attempt to find element by statement account id
+                foundElem ||= _.find(statement.accounts, (account) -> account.account_id == sElem)
 
           $scope.selectedElements.push(foundElem) if foundElem
 
@@ -180,7 +182,7 @@ module.controller('WidgetAccountsProfitAndLossCtrl', ($scope, $q, ChartFormatter
 
   $scope.getSelectLineColor = (elem) ->
     ChartFormatterSvc.getColor(_.indexOf($scope.selectedElements, elem)) if $scope.hasElements()
-  
+
 
   # Chart formating function
   # --------------------------------------
@@ -238,7 +240,12 @@ module.controller('WidgetAccountsProfitAndLossCtrl', ($scope, $q, ChartFormatter
     selectedElementsSetting.initialized = true
 
   selectedElementsSetting.toMetadata = ->
-    {selectedElements: $scope.selectedElements}
+    # Build simple array of identifiers for metadata storage
+    selectedElementsMetadata = _.map($scope.selectedElements, (element)->
+      matcher = (if element.account_id? then 'account_id' else 'name')
+      element[matcher]
+    )
+    {selectedElements: selectedElementsMetadata}
 
   w.settings.push(selectedElementsSetting)
 

--- a/src/components/widgets/hr-payroll-summary/hr-payroll-summary.directive.coffee
+++ b/src/components/widgets/hr-payroll-summary/hr-payroll-summary.directive.coffee
@@ -29,18 +29,17 @@ module.controller('WidgetHrPayrollSummaryCtrl', ($scope, $q, ChartFormatterSvc, 
 
       $scope.unCollapsed = w.metadata.unCollapsed || []
 
-      if w.metadata.selectedElements
+      unless _.isEmpty(w.metadata.selectedElements)
         $scope.selectedElements = []
         angular.forEach(w.metadata.selectedElements, (sElem) ->
-          foundElem = _.find(w.content.summary, (statement)->
-            statement.name == sElem.name
-          )
+          # Attempt to find element by statement name
+          foundElem = _.find(w.content.summary, (statement)-> statement.name == sElem)
 
-          if !foundElem
+          unless foundElem
             angular.forEach(w.content.summary, (statement) ->
-              foundElem ||= _.find(statement.employees, (employee)->
-                sElem.id == employee.id
-              ) if statement.employees?
+              if statement.employees?
+                # Attempt to find element by statement employee id
+                foundElem ||= _.find(statement.employees, (employee)-> employee.id == sElem)
             )
 
           $scope.selectedElements.push(foundElem) if foundElem
@@ -176,7 +175,7 @@ module.controller('WidgetHrPayrollSummaryCtrl', ($scope, $q, ChartFormatterSvc, 
 
   $scope.getSelectLineColor = (elem) ->
     ChartFormatterSvc.getColor(_.indexOf($scope.selectedElements, elem)) if $scope.hasElements()
-  
+
 
   # Chart formating function
   # --------------------------------------
@@ -253,7 +252,12 @@ module.controller('WidgetHrPayrollSummaryCtrl', ($scope, $q, ChartFormatterSvc, 
     selectedElementsSetting.initialized = true
 
   selectedElementsSetting.toMetadata = ->
-    {selectedElements: $scope.selectedElements}
+    # Build simple array of identifiers for metadata storage
+    selectedElementsMetadata = _.map($scope.selectedElements, (element)->
+      matcher = (if element.id? then 'id' else 'name')
+      element[matcher]
+    )
+    {selectedElements: selectedElementsMetadata}
 
   w.settings.push(selectedElementsSetting)
 

--- a/src/components/widgets/invoices-aged-payables-receivables/invoices-aged-payables-receivables.directive.coffee
+++ b/src/components/widgets/invoices-aged-payables-receivables/invoices-aged-payables-receivables.directive.coffee
@@ -28,18 +28,21 @@ module.controller('WidgetInvoicesAgedPayablesReceivablesCtrl', ($scope, $q, $log
 
       $scope.unCollapsed = w.metadata.unCollapsed || []
 
-      if w.metadata.selectedElements
+      unless _.isEmpty(w.metadata.selectedElements)
         $scope.selectedElements = []
         angular.forEach(w.metadata.selectedElements, (sElem) ->
-          foundElem = w.content.payables if sElem.name == "aged_payables"
-          foundElem = w.content.receivables if sElem.name == "aged_receivables" && !foundElem
+          # Attempt to find element by content type name
+          foundElem = w.content.payables if sElem == "aged_payables"
+          foundElem = w.content.receivables if sElem == "aged_receivables" && !foundElem
 
+          # Attempt to find element by supplier id
           foundElem = _.find(w.content.payables.suppliers, (supplier)->
-            supplier.id == sElem.id
+            supplier.id == sElem
           ) if !foundElem
 
+          # Attempt to find element by customer id
           foundElem = _.find(w.content.receivables.customers, (customer)->
-            customer.id == sElem.id
+            customer.id == sElem
           ) if !foundElem
 
           $scope.selectedElements.push(foundElem) if foundElem
@@ -218,7 +221,12 @@ module.controller('WidgetInvoicesAgedPayablesReceivablesCtrl', ($scope, $q, $log
     selectedElementsSetting.initialized = true
 
   selectedElementsSetting.toMetadata = ->
-    {selectedElements: $scope.selectedElements}
+    # Build simple array of identifiers for metadata storage
+    selectedElementsMetadata = _.map($scope.selectedElements, (element)->
+      matcher = (if element.id? then 'id' else 'name')
+      element[matcher]
+    )
+    {selectedElements: selectedElementsMetadata}
 
   w.settings.push(selectedElementsSetting)
 


### PR DESCRIPTION
@cesar-tonnoir this fixes the issue were massive `selectedElements` arrays of hashes were being saved and parsed into params. I instead on toMetadata, build an array of identifiers, and then let the initContext construct it back into hashes for display etc. 

As previously noted in the code, it could probably be moved out into a widget-settings, but as it would probably take me around 1.5 man-days, I decided to just quickly patch the problem for now.