### PR TITLE
[IMPAC-397] Enforce at least 1 opp-funnel option selection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### v1.4.10 | 2017 - Week 14
 
 #### Adds
+- [IMPAC-397] Enforce at least 1 opportunities funnel widget option selection
 - [IMPAC-535] common-currency-conversions (directive to display more information on currency conversions)
 - Aged Payables and Receivables to use common-currency-conversions directive
 


### PR DESCRIPTION
@cesar-tonnoir this fixes an issue i discovered when you deselect an assignee, then delete all your opportunities, refresh the widget so there is "no data found", then add an opp of the previously deselected assignee, the widget would show nothing. Note this is similar, but a different issue to what was raised on JIRA IMPAC-397. 

The fix for 397 is in the Impac! PR: https://github.com/maestrano/impac/pull/444