### PR TITLE
[IMPAC-262] Fix incorrect tooltip values

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Impac! Frontend Changelog
 
-### v1.4.10 | 2017 - Week 14
+### v1.4.10 | 2017 - Week 15
 
 #### Adds
 - [IMPAC-527] sales segmented minor display improvements: add currency to graph tooltip, & improve price range legend bootstrap col spacing for larger numbers

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### v1.4.10 | 2017 - Week 14
 
 #### Adds
+- [IMPAC-262] Fix new vs existing customer widget incorrect tooltip values
 - [IMPAC-535] common-currency-conversions (directive to display more information on currency conversions)
 - Aged Payables and Receivables to use common-currency-conversions directive
 

--- a/src/components/widgets/sales-new-vs-existing-customers/sales-new-vs-existing-customers.directive.coffee
+++ b/src/components/widgets/sales-new-vs-existing-customers/sales-new-vs-existing-customers.directive.coffee
@@ -66,10 +66,13 @@ module.controller('WidgetSalesNewVsExistingCustomersCtrl', ($scope, $q, ChartFor
   $scope.shouldDisplayCurrency = () ->
     $scope.isDataFound && $scope.displayType.value.indexOf('count') < 0
 
+  # Calculate a percentage based on absolute values for representing on a piegraph.
   $scope.calculatePercentage = (sliceType) ->
-    Math.round(
-      w.content.summary[$scope.displayType.value][sliceType] / w.content.summary[$scope.displayType.value].total * 100
-    )
+    values =
+      new: Math.abs w.content.summary[$scope.displayType.value].new
+      existing: Math.abs w.content.summary[$scope.displayType.value].existing
+    values.totals = values.new + values.existing
+    return Math.round values[sliceType] / values.totals * 100
 
   # Chart formating function
   # --------------------------------------


### PR DESCRIPTION
@cesar-tonnoir Is it correct to represent negative values on a pie graph like this? I've seen it being done on other widgets across the app (e.g assets summary), so I thought I would stick to it and just fix the percentage calculation for the tooltip. 

Maybe we should consider using the Polar Area chart (not yet integrated with impac-angular): http://www.chartjs.org/docs/#polar-area-chart-introduction

End result:
<img width="301" alt="screen shot 2017-04-04 at 13 58 46" src="https://cloud.githubusercontent.com/assets/7486451/24657806/9f5079b4-193f-11e7-82f7-26ac2269b382.png">
<img width="301" alt="screen shot 2017-04-04 at 13 58 54" src="https://cloud.githubusercontent.com/assets/7486451/24657807/9f530260-193f-11e7-9ad8-a73a48a3cd08.png">
