### PR TITLE
Fix refreshAll kpis wrongly forcing a dashboard reload

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 #### Adds
 
 #### Fixes
+- Fix refreshAll kpis wrongly forcing a dashboard reload
 
 -------------------------------------------------------------
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 - Fix refreshAll kpis wrongly forcing a dashboard reload
+- Fix ImpacKpisSvc .load & .show method not properly applying refreshCache
 
 -------------------------------------------------------------
 

--- a/src/services/kpis/kpis.svc.coffee
+++ b/src/services/kpis/kpis.svc.coffee
@@ -77,7 +77,7 @@ angular
       unless _self.locked
         _self.locked = true
 
-        return $q.all([ImpacMainSvc.loadUserData(force), ImpacDashboardsSvc.load(force)]).then(
+        return $q.all([ImpacMainSvc.loadUserData(), ImpacDashboardsSvc.load()]).then(
           (results)->
 
             orgUids = _.pluck _self.getCurrentDashboard().data_sources, 'uid'

--- a/src/services/kpis/kpis.svc.coffee
+++ b/src/services/kpis/kpis.svc.coffee
@@ -73,7 +73,9 @@ angular
     #====================================
 
     @locked = false
-    @load = (force=false) ->
+    # @param [refreshCache] needed for refreshing cache on reports used for Impac! KPI
+    # possible_extra_params on #index.
+    @load = (refreshCache=false) ->
       unless _self.locked
         _self.locked = true
 
@@ -84,15 +86,12 @@ angular
             ssoSessionId = results[0].sso_session
 
             params =
-              metadata:
-                organization_ids: orgUids
-              opts:
-                refresh_cache: force
+              metadata: organization_ids: orgUids
+              opts: refresh_cache: refreshCache
 
             params.sso_session = ssoSessionId if ssoSessionId
 
-            promises =
-              impac: index(params)
+            promises = impac: index(params)
 
             # Get local kpis
             if ImpacRoutes.kpis.local()
@@ -115,7 +114,7 @@ angular
                     template.source = 'local'
                     _self.config.kpisTemplates.push template
 
-                $log.info("Impac! - KpisSvc: loaded (force=#{force})")
+                $log.info("Impac! - KpisSvc: loaded")
 
               (err) ->
                 $log.error('Impac! - KpisSvc: Cannot retrieve kpis templates list', err)
@@ -125,7 +124,7 @@ angular
 
       else
         $log.warn "Impac! - KpisSvc: Load locked. Trying again in 1s"
-        $timeout (-> _self.load(force)), 1000
+        $timeout (-> _self.load(refreshCache)), 1000
 
     @massAssignAll = (metadata) ->
       _self.load().then(->
@@ -144,7 +143,7 @@ angular
         _self.isRefreshing = true
         _self.load(refreshCache).then(->
           for k in _self.getCurrentDashboard().kpis
-            _self.show(k).then(
+            _self.show(k, refreshCache).then(
               (renderedKpi)-> # success
               (errorResponse)-> $log.error("Unable to refresh all Kpis: #{errorResponse}")
             )
@@ -220,16 +219,12 @@ angular
       return $http.get(url)
 
     # Retrieve data for kpi from api
-    @show = (kpi) ->
+    @show = (kpi, refreshCache=false) ->
       kpi.isLoading = true
       _self.load().then(
         ->
-          fy_end_month = ImpacMainSvc.getFinancialYearEndMonth()
+          params = opts: refresh_cache: refreshCache
 
-          params = {
-            opts:
-              financial_year_end_month: fy_end_month
-          }
           params.sso_session = _self.getSsoSessionId() if _self.getSsoSessionId()
           params.targets = kpi.targets if kpi.targets?
           params.metadata = kpi.settings if kpi.settings?

--- a/src/services/widgets/widgets.svc.coffee
+++ b/src/services/widgets/widgets.svc.coffee
@@ -21,9 +21,9 @@ angular
     # ====================================
     # Load and initialize
     # ====================================
-    @load = (force=false) ->
-      if !_self.getSsoSessionId()? || force
-        $q.all([ImpacMainSvc.loadUserData(force), ImpacDashboardsSvc.load(force)])
+    @load = ->
+      unless _self.getSsoSessionId()?
+        $q.all([ImpacMainSvc.loadUserData(), ImpacDashboardsSvc.load()])
       else
         $q.resolve()
 


### PR DESCRIPTION
@cesar-tonnoir while working on IMPAC-515 (PR: https://github.com/maestrano/impac/pull/455), I noticed on sync-apps complete, two `/get_widget` requests were being made for each widget. One request for `ImpacWidgetsSvc.refreshAll` and second request because of `ImpacKpisSvc.refreshAll`.

This is because `ImpacDashboardsSvc.load` causes the widgets models to be re-set, and consequently, `.show` to be run for each of them. I don't believe the `ImpacKpisService.load` method's force param should also force the userData & dashboard reload.
