### PR TITLE
Improve widget selector using a Flexbox grid

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### v1.4.12 | 2017 - Week 18
 
 #### Adds
+- Improve widget selector using a Flexbox grid
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Adjust Less styling by over-riding Less Variables in the parent application.
 // Widget selector
 @impac-dashboard-widget-selector-bg:            #233845;
 @impac-dashboard-widget-selector-text-color:    white;
+@impac-dashboard-widget-selector-widget-item-min-height: 55px;
 
 // Widgets container
 @impac-placeholder-border:                      2px dashed @impac-dashboard-borders-color;

--- a/src/components/dashboard/dashboard.directive.coffee
+++ b/src/components/dashboard/dashboard.directive.coffee
@@ -279,11 +279,11 @@ module.controller('ImpacDashboardCtrl', ($scope, $http, $q, $filter, $modal, $lo
           when 'accounts'
             return {top: '33px'}
           when 'invoices'
-            return {top: '64px'}
+            return {top: '63px'}
           when 'hr'
-            return {top: '95px'}
+            return {top: '93px'}
           when 'sales'
-            return {top: '126px'}
+            return {top: '123px'}
           else
             return {top: '9999999px'}
       else
@@ -305,23 +305,21 @@ module.controller('ImpacDashboardCtrl', ($scope, $http, $q, $filter, $modal, $lo
       if widgetMetadata?
         angular.extend(params, {metadata: widgetMetadata})
       angular.element('#widget-selector').css('cursor', 'progress')
-      angular.element('#widget-selector .widgets_widget-item > *').css('cursor', 'progress')
-      angular.element('#widget-selector .categories_menu-items > p').css('cursor', 'progress')
+      angular.element('#widget-selector .section-lines .line-item').css('cursor', 'progress')
       ImpacWidgetsSvc.create(params).then(
         () ->
           $scope.errors = ''
-          angular.element('#widget-selector').css('cursor', 'auto')
-          angular.element('#widget-selector .widgets_widget-item > *').css('cursor', 'pointer')
-          angular.element('#widget-selector .categories_menu-items > p').css('cursor', 'pointer')
-          angular.element('#widget-selector .badge.confirmation').fadeTo(250,1)
+          angular.element('#widget-selector .badge.widget-added').fadeTo(250,1)
           $timeout ->
-            angular.element('#widget-selector .badge.confirmation').fadeTo(700,0)
+            angular.element('#widget-selector .badge.widget-added').fadeTo(700,0)
           ,4000
+          return
         , (errors) ->
           $scope.errors = ImpacUtilities.processRailsError(errors)
-          angular.element('#widget-selector').css('cursor', 'auto')
-          angular.element('#widget-selector .widgets_widget-item > *').css('cursor', 'pointer')
-          angular.element('#widget-selector .categories_menu-items > p').css('cursor', 'pointer')
+      )
+      .finally(->
+        angular.element('#widget-selector').css('cursor', 'auto')
+        angular.element('#widget-selector .section-lines .line-item').css('cursor', 'pointer')
       )
 
     $scope.triggerUpload = () ->

--- a/src/components/dashboard/dashboard.less
+++ b/src/components/dashboard/dashboard.less
@@ -66,19 +66,27 @@
       margin: 0;
     }
 
-    .badge.confirmation {
-      float: right;
-      margin-right: 10px;
-      opacity: 0;
-    }
-
     .title {
       padding: 15px 0px;
       border-bottom: solid 1px lighten(@impac-dashboard-widget-selector-bg,6%);
       display: flex;
       align-items: center;
-      p { flex-grow: 1; }
-      i.fa.fa-times-circle {
+
+      p.instruction {
+        flex-grow: 1;
+        margin: 0;
+        @media screen and (max-width: @screen-sm-min) {
+          width: 50%;
+          font-size: 13px;
+        }
+      }
+
+      .widget-added.badge {
+        margin-right: 10px;
+        opacity: 0;
+      }
+
+      .fa.close-selector {
         float: right;
         cursor: pointer;
         font-size: 20px;
@@ -93,124 +101,139 @@
       margin: 15px 0px;
       background-color: transparent;
       border-radius: 3px;
+    }
 
-      .categories {
-        background-color: darken(@impac-dashboard-widget-selector-bg,6%);
-        padding-bottom: 15px;
-        .row.lines {
-          p:hover {
-            background-color: darken(@impac-dashboard-widget-selector-bg,3%);
-          }
-          p.selected {
-            background-color: @impac-widget-link-color;
-            font-weight: bold;
-            .box-shadow(-2px 2px 10px -4px black);
-          }
-        }
-        .arrow {
-          position: absolute;
-          top: 33px;
-          right: -11px;
-          z-index: 1;
-          .square {
-            width: 50px;
-            height: 30px;
-            position: absolute;
-            top: 10px;
-            right: 17px;
-            background-color: @impac-widget-link-color;
-          }
-          i.fa.fa-caret-right {
-            font-size: 52px;
-            color: @impac-widget-link-color;
-            float: right;
-            position: absolute;
-            top: 0px;
-            right: 0px;
-          }
+    .section-header {
+      padding: 10px 20px;
+      font-weight: bold;
+      min-height: 40px;
+    }
+
+    .section-lines {
+      overflow-x: hidden;
+      overflow-y: scroll;
+      height: 200px;
+      margin-right: -10px;
+      margin-left: 0px;
+
+      p {
+        padding: 5px;
+        margin: 0px;
+        cursor: pointer;
+
+        &:hover, &.selected {
+          color: @impac-dashboard-widget-selector-text-color;
         }
       }
 
-      .categories_menu-items {
-        padding: 3px 12px;
+      &::-webkit-scrollbar {
+        width: 6px;
+        background-color: transparent;
       }
 
-      .widgets {
-        background-color: darken(@impac-dashboard-widget-selector-bg,3%);
-        padding-bottom: 15px;
-        .row.header {
-          text-transform: uppercase;
-          font-size: 12px;
-          color: @impac-widget-link-color;
-        }
-        .row.lines {
-          padding: 3px 0px;
-          .fa.fa-plus-circle {
-            float: right;
-            margin-top: 3px;
-          }
-        }
-      }
-
-      .widgets_widget-item {
-        padding: 0 13px;
-        display: flex;
-        align-items: center;
+      &::-webkit-scrollbar-thumb {
+        background-color: lighten(@impac-dashboard-widget-selector-bg,3%);
+        border-radius: 10px;
         &:hover {
-          background-color: darken(@impac-dashboard-widget-selector-bg,6%);
-          font-weight: normal;
+          background-color: lighten(@impac-dashboard-widget-selector-bg,6%);
+        }
+      }
+    }
+
+    .categories-section {
+      background-color: darken(@impac-dashboard-widget-selector-bg,6%);
+      padding-bottom: 15px;
+
+      & > .section-lines {
+
+        & > [class*='col-']:first-child {
+          padding: 3px 12px;
+        }
+
+        .line-item:hover {
+          background-color: darken(@impac-dashboard-widget-selector-bg,3%);
+        }
+        .line-item.selected {
+          background-color: @impac-widget-link-color;
+          font-weight: bold;
+          .box-shadow(-2px 2px 10px -4px black);
         }
       }
 
-      .widgets_widget-item_text {
-        flex-grow: 1;
-      }
+      .arrow-icon {
+        position: absolute;
+        top: 33px;
+        right: -11px;
+        z-index: 1;
 
-      .row.header {
-        padding: 10px 20px;
-        font-weight: bold;
-        min-height: 40px;
-      }
-
-      .row.lines {
-        overflow-x: hidden;
-        overflow-y: scroll;
-        height: 200px;
-        margin-right: -10px;
-        margin-left: 0px;
-        .box-shadow(inset 0px 0px 10px -4px black);
-        p {
-          padding: 5px;
-          margin: 0px;
-          border-bottom: solid 1px @impac-dashboard-widget-selector-bg;
-          cursor: pointer;
-
-          &:hover, &.selected {
-            & > div {
-              display: inline-block;
-              margin-left: 10px;
-            }
-            select {
-              margin: 0;
-            }
-            .btn {
-              height: 32px;
-              padding-top: 5px;
-            }
-            color: @impac-dashboard-widget-selector-text-color;
-          }
+        .square {
+          width: 50px;
+          height: 30px;
+          position: absolute;
+          top: 10px;
+          right: 17px;
+          background-color: @impac-widget-link-color;
         }
 
-        &::-webkit-scrollbar {
-          width: 6px;
-          background-color: transparent;
+        i.fa.fa-caret-right {
+          font-size: 52px;
+          color: @impac-widget-link-color;
+          float: right;
+          position: absolute;
+          top: 0px;
+          right: 0px;
+        }
+      }
+    }
+
+    .widgets-section {
+      background-color: darken(@impac-dashboard-widget-selector-bg,3%);
+      padding-bottom: 15px;
+
+      & > .section-header {
+        text-transform: uppercase;
+        font-size: 12px;
+        color: @impac-widget-link-color;
+      }
+
+      & > .section-lines {
+        padding: 3px 0px;
+
+        .fa.fa-plus-circle {
+          float: right;
+          margin-top: 3px;
         }
 
-        &::-webkit-scrollbar-thumb {
-          background-color: lighten(@impac-dashboard-widget-selector-bg,3%);
-          border-radius: 10px;
-          &:hover {
-            background-color: lighten(@impac-dashboard-widget-selector-bg,6%);
+        & > .line-items-grid {
+          width: 100%;
+          display: flex;
+          flex-wrap: wrap;
+          height: 0%;
+
+          & > .grid-item {
+            padding: 0 13px;
+            display: flex;
+            flex-grow: 1;
+            // Applies a flex-basis of 1/3 for each grid item (3 columns per row)
+            flex: 0 31.33%;
+            // Creates a small gutter around each grid item
+            margin: 0 1%;
+            align-items: center;
+            border-bottom: solid 1px @impac-dashboard-widget-selector-bg;
+            min-height: @impac-dashboard-widget-selector-widget-item-min-height;
+
+            @media screen and (max-width: @screen-md-min) {
+              flex: 0 100%;
+            }
+
+            &:hover {
+              background-color: darken(@impac-dashboard-widget-selector-bg,6%);
+              font-weight: normal;
+            }
+
+            p.line-item {
+              flex-grow: 1;
+            }
           }
         }
       }
@@ -218,7 +241,7 @@
 
     .bottom {
       height: 20px;
-      .suggestion {
+      & > .suggestion {
         float: right;
         opacity: 0.7;
         a {

--- a/src/components/dashboard/dashboard.tmpl.html
+++ b/src/components/dashboard/dashboard.tmpl.html
@@ -38,41 +38,41 @@
   <!-- Widgets selection container -->
   <div id="widget-selector" collapse="!showWidgetSelector()" ng-if="!customWidgetSelector.path">
     <div class="title">
-      <p>Select the widgets you want to add to your dashboard.</p>
-      <span class="badge confirmation">Widget added!</span>
-      <i class="fa fa-times-circle" ng-if="showCloseWidgetSelectorButton()" ng-click="displayWidgetSelector(false)"/>
+      <p class="instruction">Select the widgets you want to add to your dashboard.</p>
+      <span class="widget-added badge">Widget added!</span>
+      <i class="fa fa-times-circle close-selector" ng-if="showCloseWidgetSelectorButton()" ng-click="displayWidgetSelector(false)"/>
     </div>
 
     <div class="row top-container">
-      <div class="col-md-3 categories">
-        <div class="row header">
+      <div class="col-md-3 categories-section">
+        <div class="row section-header">
           All categories
         </div>
-        <div class="row lines">
-          <div class="col-md-12 categories_menu-items">
-            <p ng-click="selectCategory('accounts')" ng-class="isCategorySelected('accounts') ? 'selected' : none">Accounting</p>
-            <p ng-click="selectCategory('invoices')" ng-class="isCategorySelected('invoices') ? 'selected' : none">Invoicing</p>
-            <p ng-click="selectCategory('hr')" ng-class="isCategorySelected('hr') ? 'selected' : none">HR / Payroll</p>
-            <p ng-click="selectCategory('sales')" ng-class="isCategorySelected('sales') ? 'selected' : none">Sales</p>
+        <div class="row section-lines">
+          <div class="col-md-12">
+            <p class="line-item" ng-click="selectCategory('accounts')" ng-class="isCategorySelected('accounts') ? 'selected' : none">Accounting</p>
+            <p class="line-item" ng-click="selectCategory('invoices')" ng-class="isCategorySelected('invoices') ? 'selected' : none">Invoicing</p>
+            <p class="line-item" ng-click="selectCategory('hr')" ng-class="isCategorySelected('hr') ? 'selected' : none">HR / Payroll</p>
+            <p class="line-item" ng-click="selectCategory('sales')" ng-class="isCategorySelected('sales') ? 'selected' : none">Sales</p>
           </div>
         </div>
-
-        <div class="arrow" ng-style="getSelectedCategoryTop()">
+        <div class="arrow-icon" ng-style="getSelectedCategoryTop()">
           <div class="square"></div>
           <i class="fa fa-caret-right"></i>
         </div>
-
       </div>
 
-      <div class="col-md-9 widgets">
-        <div class="row header">
+      <div class="col-md-9 widgets-section">
+        <div class="section-header row">
           {{getSelectedCategoryName() | titleize}}
         </div>
-        <div class="row lines">
-          <div class="col-md-4 widgets_widget-item" ng-repeat="widgetPattern in getWidgetsForSelectedCategory()" ng-click="addWidget(widgetPattern.path, widgetPattern.metadata)">
-            <i class="fa fa-{{widgetPattern.icon}}" />
-            <p class="widgets_widget-item_text" tooltip="{{widgetPattern.desc}}" tooltip-placement="{{$index < 9 ? 'bottom' : 'top'}}" tooltip-animation="false"  tooltip-append-to-body="true" tooltip-class="impac-widget-selector-tooltip" ng-bind="widgetPattern.name"></p>
-            <i class="fa fa-plus-circle" />
+        <div class="section-lines">
+          <div class="line-items-grid">
+            <div class="grid-item" ng-repeat="widgetPattern in getWidgetsForSelectedCategory()" ng-click="addWidget(widgetPattern.path, widgetPattern.metadata)" tooltip="{{widgetPattern.desc}}" tooltip-placement="{{$index < 9 ? 'bottom' : 'top'}}" tooltip-animation="false"  tooltip-append-to-body="true" tooltip-class="impac-widget-selector-tooltip">
+              <i class="fa fa-{{widgetPattern.icon}} line-item" />
+              <p class="line-item" ng-bind="widgetPattern.name"></p>
+              <i class="fa fa-plus-circle line-item" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/stylesheets/variables.less
+++ b/src/stylesheets/variables.less
@@ -93,6 +93,7 @@
 // Widget selector
 @impac-dashboard-widget-selector-bg:            #233845;
 @impac-dashboard-widget-selector-text-color:    white;
+@impac-dashboard-widget-selector-widget-item-min-height: 55px;
 
 // Widgets container
 @impac-placeholder-border:                      2px dashed @impac-dashboard-borders-color;


### PR DESCRIPTION
The main advantage is row columns will always be the same height, with a configurable min-height. 

Note: a Flexbox limitation is when a column's context wraps (e.g widget name), pushing beyond the minimum height, the columns on **that row** will match the height. But the columns on the previous/following wrapped rows will not ([See link here](http://stackoverflow.com/questions/36004926/is-it-possible-to-have-equal-height-columns-in-a-multi-line-flex-container)).

On the screenshot below, the screen size is reduce so some of the widget names are wrapping. The rows with at least one column with a wrapped widget name, are then all larger to accommodate this. As you may see, the last row's columns are smaller. This is apart of the limitation noted above. I still think this is a big win, and while not perfect looks natural.
<img width="951" alt="screen shot 2017-05-04 at 14 28 00" src="https://cloud.githubusercontent.com/assets/7486451/25705665/fd6dc904-30d5-11e7-8e81-51085ad964a2.png">

The screenshot below has no widget names wrapping, so is flexing perfectly with a column height of 40px.
<img width="1151" alt="screen shot 2017-05-04 at 14 29 34" src="https://cloud.githubusercontent.com/assets/7486451/25705703/1f969fa6-30d6-11e7-9f1f-88f18dc0cf39.png">


- Responsive behaviour tested on all browser screen sizes, ipad, iphone 5/6. 
- Browser compatibility tested on Chrome, Firefox & Safari.

FYI @ouranos @hedudelgado 