### PR TITLE
Fix/default bolts

### DIFF
--- a/src/services/routes/routes.svc.coffee
+++ b/src/services/routes/routes.svc.coffee
@@ -45,12 +45,10 @@ angular
       organizations:
         appInstancesSync: null
 
-    # Default bolts (proxied by Impac! API) - can be replaced in configuration
+    # Default bolts (proxied by Impac! API) - to be defined in configuration
     bolts = 
       version: 'v2'
-      engines: [
-        { provider: 'maestrano', name: 'finance', category: 'accounts' }
-      ]
+      engines: []
 
     #=======================================
     # Local helper methods

--- a/workspace/app/app.js
+++ b/workspace/app/app.js
@@ -97,7 +97,7 @@ module.run(function (ImpacLinking, ImpacAssets, ImpacRoutes, ImpacTheming, Impac
   // Configure ImpacRoutes
   // -------------------------------------------------------
   ImpacRoutes.configureRoutes(DevSettings.buildRoutesConfig(defaults.mnoeUrl, defaults.impacUrl, defaults.multipleWatchableMode));
-  ImpacRoutes.configureBolts(defaults.bolts.version, defaults.bolts.engines)
+  ImpacRoutes.configureBolts('v2', defaults.bolts)
 
 
   // Configure ImpacTheming - aesthetic and feature customisations across the app

--- a/workspace/app/services/dev-settings.svc.js
+++ b/workspace/app/services/dev-settings.svc.js
@@ -42,12 +42,9 @@ angular.module('impacWorkspace').service('DevSettings', function ($q, ImpacRoute
       //   width: 3
       // },
     ],
-    bolts: {
-      version: 'v2',
-      engines: [
-        { provider: 'maestrano', name: 'finance', category: 'accounts' }
-      ]
-    }
+    bolts: [
+      { provider: 'maestrano', name: 'finance', category: 'accounts' }
+    ]
   };
 
   this._defaults = angular.copy(DEFAULTS);


### PR DESCRIPTION
By default, no bolt should be configured => will allow frontends to update impac-angular v1.5.1 without loading the bolt widgets

(deployed on impac-express)