### PR TITLE
Add gulp interval improving CPU perf

### DIFF
--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -11,9 +11,8 @@ var conf = require('./conf');
 var browserSync = require('browser-sync');
 
 gulp.task('watch', function () {
-  gulp.watch('bower_components/**/*', ['workspace', browserSync.reload]);
-  gulp.watch('src/**/*', ['build', browserSync.reload]);
-  gulp.watch('workspace/**/*', function (event) {
+  gulp.watch('src/**/*', { interval: 1500 }, ['build', browserSync.reload]);
+  gulp.watch('workspace/**/*', { interval: 1500 }, function (event) {
     browserSync.reload(event.path);
   });
 });


### PR DESCRIPTION
@cesar-tonnoir improves cpu perf by ~30% running serve. Also removed the bower_components watch as it's pretty unnecessary to be watching all those files just so when a component is bower installed it reloads; can just re-run the task on that case. 

:beers: