### PR TITLE
[IMPAC-592] use instant translations during w.initContext

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 - Delegate i18n configuration to the host app
+- Fixes some widgets breaking during load because w.initContext is not designed for async definitions (i18n async translations were being made).
 
 #### Config changes
 - Remove `translateSettings` from ThemingSvc

--- a/src/components/widgets/hr-salaries-summary/hr-salaries-summary.directive.coffee
+++ b/src/components/widgets/hr-salaries-summary/hr-salaries-summary.directive.coffee
@@ -24,41 +24,29 @@ module.controller('WidgetHrSalariesSummaryCtrl', ($scope, $q, ChartFormatterSvc,
   # Widget specific methods
   # --------------------------------------
   w.initContext = ->
-    if $scope.isDataFound = !_.isEmpty(w.content) && w.content.summary? && !_.isEmpty(w.content.summary.data)
+    $scope.isDataFound = !_.isEmpty(w.content) && w.content.summary? && !_.isEmpty(w.content.summary.data)
 
-      $translate([
-        "impac.widget.settings.time_period.period.yearly",
-        "impac.widget.settings.time_period.period.monthly",
-        "impac.widget.settings.time_period.period.weekly",
-        "impac.widget.settings.time_period.period.hourly"]).then(
-        (translations) ->
-          $scope.periodOptions = [
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.yearly"].toLowerCase()), value: "yearly"},
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.monthly"].toLowerCase()), value: "monthly"},
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.weekly"].toLowerCase()), value: "weekly"},
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.hourly"].toLowerCase()), value: "hourly"}
-          ]
+    if $scope.isDataFound
+      $scope.periodOptions = [
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.yearly").toLowerCase()), value: "yearly"},
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.monthly").toLowerCase()), value: "monthly"},
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.weekly").toLowerCase()), value: "weekly"},
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.hourly").toLowerCase()), value: "hourly"}
+      ]
 
-          $scope.period = angular.copy(_.find($scope.periodOptions, (o) ->
-              o.value == w.content.total.period.toLowerCase()
-            ) || $scope.periodOptions[0])
-      )
+      $scope.filterOptions = [
+        {label: $translate.instant("impac.common.label.gender"), value: "gender"},
+        {label: $translate.instant("impac.common.label.age_range"), value: "age_range"},
+        {label: $translate.instant("impac.common.label.job_title"), value: "job_title"},
+      ]
 
-      $translate([
-        "impac.common.label.gender",
-        "impac.common.label.age_range",
-        "impac.common.label.job_title"]).then(
-        (translations) ->
-          $scope.filterOptions = [
-            {label: translations["impac.common.label.gender"], value: "gender"},
-            {label: translations["impac.common.label.age_range"], value: "age_range"},
-            {label: translations["impac.common.label.job_title"], value: "job_title"},
-          ]
+      $scope.period = angular.copy(_.find($scope.periodOptions, (o) ->
+          o.value == w.content.total.period.toLowerCase()
+        ) || $scope.periodOptions[0])
 
-          $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
-              o.value == w.content.summary.filter
-            ) || $scope.filterOptions[0])
-      )
+      $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
+          o.value == w.content.summary.filter
+        ) || $scope.filterOptions[0])
 
   $scope.getColorByIndex = (index) ->
     ChartFormatterSvc.getColor(index)

--- a/src/components/widgets/hr-workforce-summary/hr-workforce-summary.directive.coffee
+++ b/src/components/widgets/hr-workforce-summary/hr-workforce-summary.directive.coffee
@@ -24,43 +24,30 @@ module.controller('WidgetHrWorkforceSummaryCtrl', ($scope, $q, ChartFormatterSvc
   # Widget specific methods
   # --------------------------------------
   w.initContext = ->
-    if $scope.isDataFound = !_.isEmpty(w.content) && w.content.summary? && !_.isEmpty(w.content.summary.data)
+    $scope.isDataFound = !_.isEmpty(w.content) && w.content.summary? && !_.isEmpty(w.content.summary.data)
 
-      $translate([
-        "impac.widget.settings.time_period.period.yearly",
-        "impac.widget.settings.time_period.period.monthly",
-        "impac.widget.settings.time_period.period.weekly",
-        "impac.widget.settings.time_period.period.hourly"]).then(
-        (translations) ->
-          $scope.periodOptions = [
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.yearly"].toLowerCase()), value: "yearly"},
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.monthly"].toLowerCase()), value: "monthly"},
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.weekly"].toLowerCase()), value: "weekly"},
-            {label: _.capitalize(translations["impac.widget.settings.time_period.period.hourly"].toLowerCase()), value: "hourly"}
-          ]
+    if $scope.isDataFound
+      $scope.periodOptions = [
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.yearly").toLowerCase()), value: "yearly"},
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.monthly").toLowerCase()), value: "monthly"},
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.weekly").toLowerCase()), value: "weekly"},
+        {label: _.capitalize($translate.instant("impac.widget.settings.time_period.period.hourly").toLowerCase()), value: "hourly"}
+      ]
 
-          $scope.period = angular.copy(_.find($scope.periodOptions, (o) ->
-              o.value == w.content.total.period.toLowerCase()
-            ) || $scope.periodOptions[0])
-      )
+      $scope.filterOptions = [
+        {label: $translate.instant("impac.common.label.gender"), value: "gender"},
+        {label: $translate.instant("impac.common.label.age_range"), value: "age_range"},
+        {label: $translate.instant("impac.common.label.salary_range"), value: "salary_range"},
+        {label: $translate.instant("impac.common.label.job_title"), value: "job_title"},
+      ]
 
-      $translate([
-        "impac.common.label.gender",
-        "impac.common.label.age_range",
-        "impac.common.label.salary_range",
-        "impac.common.label.job_title"]).then(
-        (translations) ->
-          $scope.filterOptions = [
-            {label: translations["impac.common.label.gender"], value: "gender"},
-            {label: translations["impac.common.label.age_range"], value: "age_range"},
-            {label: translations["impac.common.label.salary_range"], value: "salary_range"},
-            {label: translations["impac.common.label.job_title"], value: "job_title"},
-          ]
+      $scope.period = angular.copy(_.find($scope.periodOptions, (o) ->
+          o.value == w.content.total.period.toLowerCase()
+        ) || $scope.periodOptions[0])
 
-          $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
-              o.value == w.content.summary.filter
-            ) || $scope.filterOptions[0])
-      )
+      $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
+          o.value == w.content.summary.filter
+        ) || $scope.filterOptions[0])
 
   $scope.getTotalWorkforce = ->
     w.content.total.amount if $scope.isDataFound

--- a/src/components/widgets/sales-aged/sales-aged.directive.coffee
+++ b/src/components/widgets/sales-aged/sales-aged.directive.coffee
@@ -22,23 +22,18 @@ module.controller('WidgetSalesAgedCtrl', ($scope, $q, ChartFormatterSvc, $filter
   # Widget specific methods
   # --------------------------------------
   w.initContext = ->
-    if $scope.isDataFound = angular.isDefined(w.content) && !_.isEmpty(w.content.aged_sales) && !_.isEmpty(w.content.dates)
+    $scope.isDataFound = angular.isDefined(w.content) && !_.isEmpty(w.content.aged_sales) && !_.isEmpty(w.content.dates)
 
-      $translate([
-        "impac.widget.sales_aged.value_sold_taxes",
-        "impac.widget.sales_aged.value_sold_no_taxes",
-        "impac.widget.sales_aged.quantity_sold"]).then(
-          (translations) ->
-            $scope.filterOptions = [
-              {label: translations["impac.widget.sales_aged.value_sold_taxes"], value: 'gross_value_sold'},
-              {label: translations["impac.widget.sales_aged.value_sold_no_taxes"], value: 'net_value_sold'},
-              {label: translations["impac.widget.sales_aged.quantity_sold"], value: 'quantity_sold'}
-            ]
+    if $scope.isDataFound
+      $scope.filterOptions = [
+        {label: $translate.instant("impac.widget.sales_aged.value_sold_taxes"), value: 'gross_value_sold'},
+        {label: $translate.instant("impac.widget.sales_aged.value_sold_no_taxes"), value: 'net_value_sold'},
+        {label: $translate.instant("impac.widget.sales_aged.quantity_sold"), value: 'quantity_sold'}
+      ]
 
-            $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
-                w.metadata && w.metadata.filter == o.value
-              ) || $scope.filterOptions[0])
-        )
+      $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
+          w.metadata && w.metadata.filter == o.value
+        ) || $scope.filterOptions[0])
 
   $scope.getTotal = (anIndex) ->
     if $scope.isDataFound && anIndex >=0 && anIndex < w.content.aged_sales[$scope.filter.value].length

--- a/src/components/widgets/sales-list/sales-list.directive.coffee
+++ b/src/components/widgets/sales-list/sales-list.directive.coffee
@@ -27,30 +27,21 @@ module.controller('WidgetSalesListCtrl', ($scope, $q, ChartFormatterSvc, ImpacWi
       buildFxTotals()
       $scope.ratesDate = moment.now()
 
-    $translate([
-      'impac.widget.sales_list.value_sold_taxes',
-      'impac.widget.sales_list.value_sold_no_taxes',
-      'impac.widget.sales_list.quantity_sold',
-      'impac.widget.sales_list.value_purchased_taxes',
-      'impac.widget.sales_list.value_purchased_no_taxes',
-      'impac.widget.sales_list.quantity_purchased']).then(
-      (translations) ->
-        $scope.filterOptions = [
-          {label: translations['impac.widget.sales_list.value_sold_taxes'], value: 'gross_value_sold'},
-          {label: translations['impac.widget.sales_list.value_sold_no_taxes'], value: 'net_value_sold'},
-          {label: translations['impac.widget.sales_list.quantity_sold'], value: 'quantity_sold'},
-          {label: translations['impac.widget.sales_list.value_purchased_taxes'], value: 'gross_value_purchased'},
-          {label: translations['impac.widget.sales_list.value_purchased_no_taxes'], value: 'net_value_purchased'},
-          {label: translations['impac.widget.sales_list.quantity_purchased'], value: 'quantity_purchased'}
-        ]
+      $scope.filterOptions = [
+        {label: $translate.instant('impac.widget.sales_list.value_sold_taxes'), value: 'gross_value_sold'},
+        {label: $translate.instant('impac.widget.sales_list.value_sold_no_taxes'), value: 'net_value_sold'},
+        {label: $translate.instant('impac.widget.sales_list.quantity_sold'), value: 'quantity_sold'},
+        {label: $translate.instant('impac.widget.sales_list.value_purchased_taxes'), value: 'gross_value_purchased'},
+        {label: $translate.instant('impac.widget.sales_list.value_purchased_no_taxes'), value: 'net_value_purchased'},
+        {label: $translate.instant('impac.widget.sales_list.quantity_purchased'), value: 'quantity_purchased'}
+      ]
 
-        $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
-          o.value == w.metadata.filter
-        ) || $scope.filterOptions[0])
-    )
-    
-    $scope.unCollapsed = w.metadata.unCollapsed || []
-    sortData()
+      $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
+        o.value == w.metadata.filter
+      ) || $scope.filterOptions[0])
+
+      $scope.unCollapsed = w.metadata.unCollapsed || []
+      sortData()
 
   $scope.toggleCollapsed = (categoryName) ->
     if categoryName?
@@ -105,9 +96,9 @@ module.controller('WidgetSalesListCtrl', ($scope, $q, ChartFormatterSvc, ImpacWi
               saleFxTotals.push({
                 currency: currency,
                 amount: amount,
-                rate: total.rate  
+                rate: total.rate
               })
-        
+
         sale.formattedFxTotals = saleFxTotals unless _.isEmpty(saleFxTotals)
 
   # Mini-settings

--- a/src/components/widgets/sales-margin/sales-margin.directive.coffee
+++ b/src/components/widgets/sales-margin/sales-margin.directive.coffee
@@ -26,20 +26,17 @@ module.controller('WidgetSalesMarginCtrl', ($scope, $q, ChartFormatterSvc, $filt
   w.initContext = ->
     $scope.isDataFound = w.content? && w.content.margins? && w.content.dates?
 
-    $translate([
-      'impac.widget.sales_margin.including_taxes',
-      'impac.widget.sales_margin.excluding_taxes']).then(
-        (translations) ->
-          $scope.filterOptions = [
-            {label: translations['impac.widget.sales_margin.including_taxes'], value: 'gross_margin'},
-            {label: translations['impac.widget.sales_margin.excluding_taxes'], value: 'net_margin'}
-          ]
+    if $scope.isDataFound
+      $scope.filterOptions = [
+        {label: $translate.instant('impac.widget.sales_margin.including_taxes'), value: 'gross_margin'},
+        {label: $translate.instant('impac.widget.sales_margin.excluding_taxes'), value: 'net_margin'}
+      ]
 
-          if w.metadata? && w.metadata.filter=="net_margin"
-            $scope.filter = angular.copy $scope.filterOptions[1]
-          else
-            $scope.filter = angular.copy $scope.filterOptions[0]
-      )
+      if w.metadata? && w.metadata.filter=="net_margin"
+        $scope.filter = angular.copy $scope.filterOptions[1]
+      else
+        $scope.filter = angular.copy $scope.filterOptions[0]
+
   $scope.getTotalMargin = ->
     if $scope.isDataFound
       if w.metadata? && w.metadata.filter=="net_margin"

--- a/src/components/widgets/sales-segmented-turnover/sales-segmented-turnover.directive.coffee
+++ b/src/components/widgets/sales-segmented-turnover/sales-segmented-turnover.directive.coffee
@@ -26,32 +26,21 @@ module.controller('WidgetSalesSegmentedTurnoverCtrl', ($scope, $q, $filter, Char
   w.initContext = ->
     if $scope.isDataFound = !_.isEmpty(w.content) && !_.isEmpty(w.content.dates) && !_.isEmpty(w.content.ranges)
 
-      $translate([
-        'impac.widget.sales_turnover.gross_revenue',
-        'impac.widget.sales_turnover.net_revenue']).then(
-          (translations) ->
-            $scope.filterOptions = [
-              {label: translations['impac.widget.sales_turnover.gross_revenue'], value: 'gross'},
-              {label: translations['impac.widget.sales_turnover.net_revenue'], value: 'net'},
-            ]
+      $scope.filterOptions = [
+        {label: $translate.instant('impac.widget.sales_turnover.gross_revenue'), value: 'gross'},
+        {label: $translate.instant('impac.widget.sales_turnover.net_revenue'), value: 'net'},
+      ]
 
-            $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
-              o.value == w.content.filter
-            ) || $scope.filterOptions[0])
-        )
+      $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
+        o.value == w.content.filter
+      ) || $scope.filterOptions[0])
 
-      $translate([
-        'impac.widget.sales_turnover.analysis.least',
-        'impac.widget.sales_turnover.analysis.most',
-        'impac.widget.sales_turnover.analysis.balanced']).then(
-        (translations) ->
-           if w.content.ranges[0].percentage + w.content.ranges[1].percentage > 50
-             $scope.analysisTranslate = translations['impac.widget.sales_turnover.analysis.least']
-           else if w.content.ranges[3].percentage + w.content.ranges[4].percentage > 50
-             $scope.analysisTranslate = translations['impac.widget.sales_turnover.analysis.most']
-           else
-             $scope.analysisTranslate = translations['impac.widget.sales_turnover.analysis.balanced']
-        )
+      if w.content.ranges[0].percentage + w.content.ranges[1].percentage > 50
+        $scope.analysisTranslate = $translate.instant('impac.widget.sales_turnover.analysis.least')
+      else if w.content.ranges[3].percentage + w.content.ranges[4].percentage > 50
+        $scope.analysisTranslate = $translate.instant('impac.widget.sales_turnover.analysis.most')
+      else
+        $scope.analysisTranslate = $translate.instant('impac.widget.sales_turnover.analysis.balanced')
 
   $scope.getColorByIndex = (index) ->
     ChartFormatterSvc.getColor(index)

--- a/src/components/widgets/sales-summary/sales-summary.directive.coffee
+++ b/src/components/widgets/sales-summary/sales-summary.directive.coffee
@@ -26,33 +26,26 @@ module.controller('WidgetSalesSummaryCtrl', ($scope, $q, ChartFormatterSvc, $tra
   # --------------------------------------
   w.initContext = ->
     $scope.isDataFound = !_.isEmpty(w.content) && !_.isEmpty(w.content.summary) && ( _.sum(_.map(w.content.summary, (s) -> s.total)) > 0 )
-    
-    $translate([
-      'impac.widget.sales_summary.value_sold_taxes',
-      'impac.widget.sales_summary.value_sold_no_taxes',
-      'impac.widget.sales_summary.quantity_sold',
-      'impac.widget.sales_summary.value_purchased_taxes',
-      'impac.widget.sales_summary.value_purchased_no_taxes',
-      'impac.widget.sales_summary.quantity_purchased']).then(
-      (translations) ->
-        $scope.filterOptions = [
-          {label: translations['impac.widget.sales_summary.value_sold_taxes'], value: 'gross_value_sold'},
-          {label: translations['impac.widget.sales_summary.value_sold_no_taxes'], value: 'net_value_sold'},
-          {label: translations['impac.widget.sales_summary.quantity_sold'], value: 'quantity_sold'},
-          {label: translations['impac.widget.sales_summary.value_purchased_taxes'], value: 'gross_value_purchased'},
-          {label: translations['impac.widget.sales_summary.value_purchased_no_taxes'], value: 'net_value_purchased'},
-          {label: translations['impac.widget.sales_summary.quantity_purchased'], value: 'quantity_purchased'}
-        ]
-        $scope.filterOptions = [
-          $scope.filterOptions[0],
-          $scope.filterOptions[1],
-          $scope.filterOptions[2]
-        ] if w.metadata.criteria == "customer"
 
-        $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
-            o.value == w.metadata.filter
-          ) || $scope.filterOptions[0])
-    )
+    if $scope.isDataFound
+      $scope.filterOptions = [
+        {label: $translate.instant('impac.widget.sales_summary.value_sold_taxes'), value: 'gross_value_sold'},
+        {label: $translate.instant('impac.widget.sales_summary.value_sold_no_taxes'), value: 'net_value_sold'},
+        {label: $translate.instant('impac.widget.sales_summary.quantity_sold'), value: 'quantity_sold'},
+        {label: $translate.instant('impac.widget.sales_summary.value_purchased_taxes'), value: 'gross_value_purchased'},
+        {label: $translate.instant('impac.widget.sales_summary.value_purchased_no_taxes'), value: 'net_value_purchased'},
+        {label: $translate.instant('impac.widget.sales_summary.quantity_purchased'), value: 'quantity_purchased'}
+      ]
+
+      $scope.filterOptions = [
+        $scope.filterOptions[0],
+        $scope.filterOptions[1],
+        $scope.filterOptions[2]
+      ] if w.metadata.criteria == "customer"
+
+      $scope.filter = angular.copy(_.find($scope.filterOptions, (o) ->
+          o.value == w.metadata.filter
+        ) || $scope.filterOptions[0])
 
   # Chart formating function
   # --------------------------------------


### PR DESCRIPTION
Fixes some widgets breaking during load because w.initContext is not designed for async definitions (i18n async translations were being made).