### PR TITLE
[IMPAC-658] Fix dependency to xeditable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,12 @@
 
 ### v1.6.1 | 2017 - Week 35
 
+#### Adds
+- Serve glyphicons in the developer workspace
+
 #### Fixes
 - Update doc with v1.6.0 changes
+- [IMPAC-658] Fix dependency to xeditable
 
 -------------------------------------------------------------
 

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -21,7 +21,8 @@ function browserSyncInit(baseDir, browser) {
     '/bower_components': 'bower_components',
     '/dist': 'dist',
     '/assets': 'workspace/assets',
-    '/locales': 'src/locales'
+    '/locales': 'src/locales', 
+    '/fonts': 'bower_components/bootstrap/fonts'
   };
 
   var server = {

--- a/src/impac-angular.module.js
+++ b/src/impac-angular.module.js
@@ -15,7 +15,8 @@ angular.module('maestrano.impac',
     'ui.bootstrap',
     'emguo.poller',
     'toastr',
-    'pascalprecht.translate'
+    'pascalprecht.translate',
+    'xeditable'
   ]);
 
 /*

--- a/src/impac-angular.run.coffee
+++ b/src/impac-angular.run.coffee
@@ -7,3 +7,7 @@ module.run((ImpacAlerts)->
   # Eager Loading the service 'ImpacAlerts', this can be removed when
   # another Impac Angular module depends on ImpacAlerts, guaranteeing its evaluation.
 )
+
+module.run((editableOptions) ->
+  editableOptions.theme = 'bs3'
+)


### PR DESCRIPTION
- Add dependency to xeditable so widgets titles can be edited without configuration in host apps
- Serve glyphicons in workspace