### PR TITLE
[IMPAC-618] Better time management for cashflow widgets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,11 @@
   "name": "impac-angular",
   "description": "Impac! Front-End Library",
   "version": "1.6.1",
+  "license": "Copyright 2017 Maestrano Pty Ltd",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/maestrano/impac-angular.git"
+  },
   "main": [
     "dist/impac-angular.js",
     "dist/impac-angular.less",
@@ -42,6 +47,11 @@
     "highcharts": "^5.0.11",
     "color": "^3.0.4"
   },
+  "overrides": { 
+    "highcharts": { 
+      "main": "highstock.js" 
+    }
+  },
   "devDependencies": {
     "angular-mocks": "~1.6.0",
     "angular-scenario": "~1.6.0",
@@ -51,11 +61,6 @@
     "angular-translate-handler-log": "~2.14.0",
     "angular-translate-loader-static-files": "^2.14.0",
     "jasmine-jquery": "^2.1.1"
-  },
-  "license": "Copyright 2017 Maestrano Pty Ltd",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/maestrano/impac-angular.git"
   },
   "resolutions": {
     "angular": "~1.6.0"

--- a/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
@@ -70,17 +70,13 @@ module.component('chartThreshold', {
       ctrl.loading = true
       params = targets: {}, metadata: {}
       params.targets[ctrl.kpi.watchables[0]] = [{
-        "#{ctrl.kpiTargetMode}": ctrl.draftTarget.value
+        "#{ctrl.kpiTargetMode}": parseFloat(ctrl.draftTarget.value)
       }]
       return unless ImpacKpisSvc.validateKpiTargets(params.targets)
       promise = if ctrl.isEditingKpi
         ImpacKpisSvc.update(getKpi(), params, false)
       else
-        # TODO: improve the way the hist_params are applied onto widget kpis
-        if ctrl.widget.metadata && (widgetHistParams = ctrl.widget.metadata.hist_parameters)
-          params.metadata.hist_parameters = widgetHistParams
-        else
-          params.metadata.hist_parameters = ImpacUtilities.yearDates()
+        params.metadata.hist_parameters = ctrl.widget.metadata.hist_parameters
         params.widget_id = ctrl.widget.id
         ImpacKpisSvc.create('impac', ctrl.kpi.endpoint, ctrl.kpi.watchables[0], params)
       promise.then(
@@ -126,15 +122,15 @@ module.component('chartThreshold', {
     onChartClick = (event)->
       # Check whether click event fired is from the 'reset zoom' button
       return if event.srcElement.textContent == 'Reset zoom'
-      # Gaurd for tooltips / other chart areas that don't return a yAxis value
+      # Guard for tooltips / other chart areas that don't return a yAxis value
       return unless event.yAxis && event.yAxis[0]
       value = event.yAxis[0].value
-      # Gaurd for click events fired outside of the yAxis values range
+      # Guard for click events fired outside of the yAxis values range
       if !value || _.isNaN(value) then return else value = value.toFixed(2)
       ctrl.createKpi(value)
 
     onThresholdClick = (thresholdSerie)->
-      thresholdValue = (opts = thresholdSerie.options).data[opts.data.length - 1]
+      thresholdValue = (opts = thresholdSerie.options).data[opts.data.length - 1][1].toFixed(2)
       ctrl.editKpi(kpiId: opts.kpiId, value: thresholdValue)
 
     disableAttachability = (logMsg)->
@@ -165,7 +161,7 @@ module.component('chartThreshold', {
       widgetHistParams = ctrl.widget.metadata && ctrl.widget.metadata.hist_parameters
       # Widget histParams are YTD by default (when undefined on metadata),
       # therefore in the past by default
-      ctrl.disabled = _.isEmpty(widgetHistParams) || moment(widgetHistParams.to) <= moment().startOf('day')
+      ctrl.disabled = widgetHistParams? && moment(widgetHistParams.to) <= moment.utc().startOf('day')
       return
 
     return ctrl

--- a/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
@@ -159,8 +159,6 @@ module.component('chartThreshold', {
     # Disable threshold when selected time period is strictly in the past
     validateHistParameters = ->
       widgetHistParams = ctrl.widget.metadata && ctrl.widget.metadata.hist_parameters
-      # Widget histParams are YTD by default (when undefined on metadata),
-      # therefore in the past by default
       ctrl.disabled = widgetHistParams? && moment(widgetHistParams.to) <= moment.utc().startOf('day')
       return
 

--- a/src/components/widgets-common/chart-threshold/chart-threshold.less
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.less
@@ -37,16 +37,8 @@ chart-threshold {
     button {
       padding: 3px 6px;
       display: inline-block;
-    }
-
-    & > .btn.has-spinner {
-      outline: none;
-      i {
-        padding: 0 15px;
-        outline: none;
-      }
-      span {
-        outline: none;
+      &.loading {
+        padding: 3px 20px;
       }
     }
   }

--- a/src/components/widgets-common/chart-threshold/chart-threshold.less
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.less
@@ -40,7 +40,14 @@ chart-threshold {
     }
 
     & > .btn.has-spinner {
-      i { padding: 0 15px; }
+      outline: none;
+      i {
+        padding: 0 15px;
+        outline: none;
+      }
+      span {
+        outline: none;
+      }
     }
   }
 }

--- a/src/components/widgets-common/chart-threshold/chart-threshold.tmpl.html
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.tmpl.html
@@ -6,11 +6,11 @@
   </div>
   <div class="action-buttons">
     <button class="btn btn-default" ng-click="$ctrl.cancelCreateKpi()" ng-disabled="$ctrl.loading">Cancel</button>
-    <button class="btn btn-primary has-spinner" ng-click="$ctrl.saveKpi()">
+    <button class="btn btn-primary" ng-class="{'loading': $ctrl.loading}" ng-click="$ctrl.saveKpi()">
       <i ng-show="$ctrl.loading" class="fa fa-spinner fa-spin" aria-hidden="true"></i>
       <span ng-hide="$ctrl.loading">{{$ctrl.isEditingKpi ? 'Update' : 'Save'}}</span>
     </button>
-    <button ng-if="$ctrl.isEditingKpi" class="btn btn-danger has-spinner" ng-click="$ctrl.deleteKpi()">
+    <button ng-if="$ctrl.isEditingKpi" class="btn btn-danger" ng-class="{'loading': $ctrl.loading}" ng-click="$ctrl.deleteKpi()">
       <i ng-show="$ctrl.loading" class="fa fa-spinner fa-spin" aria-hidden="true"></i>
       <span ng-hide="$ctrl.loading">Delete</span>
     </button>

--- a/src/components/widgets-settings/dates-picker/dates-picker.directive.coffee
+++ b/src/components/widgets-settings/dates-picker/dates-picker.directive.coffee
@@ -16,6 +16,7 @@ module.directive('settingDatesPicker', ($templateCache, $filter, ImpacWidgetsSvc
       minDate: '=?'
       updateOnPick: '=?'
       template: '=?'
+      period: '=?'
     },
     template: $templateCache.get('widgets-settings/dates-picker.tmpl.html'),
 
@@ -112,7 +113,7 @@ module.directive('settingDatesPicker', ($templateCache, $filter, ImpacWidgetsSvc
           hist_parameters:
             from: $filter('date')(scope.calendarFrom.value, 'yyyy-MM-dd')
             to: $filter('date')(scope.calendarTo.value, 'yyyy-MM-dd')
-            period: "RANGE"
+            period: scope.period || "RANGE"
             keep_today: isToToday()
         }
 

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
@@ -6,12 +6,18 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
   # Define settings
   # --------------------------------------
   $scope.orgDeferred = $q.defer()
-  $scope.timePeriodDeferred = $q.defer()
+  $scope.datesPickerDeferred = $q.defer()
 
   settingsPromises = [
     $scope.orgDeferred.promise,
-    $scope.timePeriodDeferred.promise
+    $scope.datesPickerDeferred.promise
   ]
+
+  # Dates picker defaults
+  $scope.fromDate = moment().subtract(3, 'months').format('YYYY-MM-DD')
+  $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
+  $scope.period = 'DAILY'
+  $scope.keepToday = false
 
   # Widget specific methods
   # --------------------------------------
@@ -25,6 +31,10 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
     # chartColors = ImpacTheming.get().chartColors
     # Set chart accounts series colors by account bias ('positive' / 'negative')
     setSeriesColors(w.content.chart.series, { positive: '#3FC4FF', negative: '#e50228'})
+
+    if hist = w.metadata.hist_parameters
+      $scope.fromDate = hist.from
+      $scope.toDate = hist.to
 
   $scope.legendItemOnClick = (account)->
     serie = $scope.chart? && $scope.chart.hc? && getSerieByAccount($scope.chart.hc.series, account)

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
@@ -4,12 +4,11 @@
   .data-container {
     height: ~"calc(@{impac-big-widget-size} - 20px)";
     width: 100%;
-    display: flex;
   }
 
   .left-panel {
-    flex: 0;
-    min-width: 180px;
+    width: 180px;
+    display: inline-block;
     overflow: auto;
   }
 
@@ -43,19 +42,12 @@
   }
 
   .right-panel {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    position: relative;
-
-    .top-bar {
-      flex: 0;
-      min-height: 50px;
-    }
+    width: ~"calc(100% - 180px)";
+    float: right;
 
     // Highchart container
     .cash-balance-chart {
-      flex: 1;
+      height: ~"calc(@{impac-big-widget-size} - 50px)";
     }
   }
 }

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
@@ -2,7 +2,7 @@
   .tall-widget();
 
   .data-container {
-    height: ~"calc(@{impac-big-widget-size} - 20px)";
+    height: ~"calc(@{impac-big-widget-size} - 50px)";
     width: 100%;
   }
 
@@ -49,5 +49,11 @@
     .cash-balance-chart {
       height: ~"calc(@{impac-big-widget-size} - 50px)";
     }
+  }
+
+  .dates-picker {
+    display: inline-block;
+    float: right;
+    font-size: 12px;
   }
 }

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
@@ -35,7 +35,6 @@
         </div>
       </div>
       <div class="right-panel">
-        <div class="top-bar"></div>
         <div id="{{chartId()}}" class="cash-balance-chart"></div>
       </div>
     </div>

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
@@ -7,7 +7,6 @@
     <h4>Widget settings</h4>
 
     <div setting-organizations parent-widget="widget" class="part" deferred="::orgDeferred" />
-    <div setting-time-period parent-widget="widget" class="part" deferred="::timePeriodDeferred" hist-params="widget.metadata.hist_parameters" />
 
     <!-- Buttons displayed on the lower  -->
     <div class="bottom-buttons" align="right">
@@ -38,6 +37,8 @@
         <div id="{{chartId()}}" class="cash-balance-chart"></div>
       </div>
     </div>
+
+    <div setting-dates-picker class="dates-picker" parent-widget="widget" deferred="::datesPickerDeferred" from="fromDate" to="toDate" period="period" keep-today="keepToday" update-on-pick="true"/>
 
     <div ng-show="widget.demoData" common-data-not-found />
   </div>

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -63,7 +63,6 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     options =
       chartType: 'line'
       currency: w.metadata.currency
-      period: getPeriod()
       showToday: true
       showLegend: true
       thresholds: getThresholds()

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -41,8 +41,9 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     $scope.isDataFound = w.content?
 
     # Offset will be applied to all intervals after today
-    todayInterval = w.content.chart.series[0].zones[0].value
-    $scope.intervalsCount = w.content.chart.labels.length - todayInterval
+    todayInterval = _.findIndex w.content.chart.series[0].data, (vector) ->
+      vector[0] >= moment.now()
+    $scope.intervalsCount = w.content.chart.series[0].data.length - todayInterval
 
     projectedSerie = _.find w.content.chart.series, (serie) ->
       serie.name == "Projected cash"

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -6,13 +6,13 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   # Define settings
   # --------------------------------------
   $scope.orgDeferred = $q.defer()
-  $scope.timePeriodDeferred = $q.defer()
+  $scope.datesPickerDeferred = $q.defer()
   $scope.intervalsOffsetsDeferred = $q.defer()
   $scope.currentOffsetsDeferred = $q.defer()
 
   settingsPromises = [
     $scope.orgDeferred.promise,
-    $scope.timePeriodDeferred.promise,
+    $scope.datesPickerDeferred.promise,
     $scope.intervalsOffsetsDeferred.promise,
     $scope.currentOffsetsDeferred.promise
   ]
@@ -27,6 +27,12 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   $scope.chartThresholdOptions = {
     label: 'Get alerted when the cash projection goes below'
   }
+
+  # Dates picker defaults
+  $scope.fromDate = moment().subtract(3, 'months').format('YYYY-MM-DD')
+  $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
+  $scope.period = 'DAILY'
+  $scope.keepToday = false
 
   # Widget specific methods
   # --------------------------------------
@@ -57,6 +63,10 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       $scope.currentProjectedCash = projectedSerie.data[todayInterval] - totalOffset
 
     $scope.isTimePeriodInThePast = w.metadata.hist_parameters && moment(w.metadata.hist_parameters.to) < moment().startOf('day')
+
+    if hist = w.metadata.hist_parameters
+      $scope.fromDate = hist.from
+      $scope.toDate = hist.to
 
 
   w.format = ->

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -41,6 +41,11 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     projectedSerie = _.find w.content.chart.series, (serie) ->
       serie.name == "Projected cash"
 
+    cashFlowSerie = _.find w.content.chart.series, (serie) ->
+      serie.name == "Cash flow"
+    cashFlowSerie.data = []
+    cashFlowSerie.type = 'area'
+
     totalOffset = 0.0
     if w.metadata.offset && w.metadata.offset.current && w.metadata.offset.current.length > 0
       totalOffset += _.sum(w.metadata.offset.current)

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.less
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.less
@@ -6,7 +6,6 @@
   }
 
   .highcharts-legend-item {
-
     rect.highcharts-point {
       display: none;
     }
@@ -53,5 +52,11 @@
       font-size: 20px;
       margin-top: 0px;
     }
+  }
+
+  .dates-picker {
+    display: inline-block;
+    float: right;
+    font-size: 12px;
   }
 }

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
@@ -4,7 +4,6 @@
     <h4>Widget settings</h4>
 
     <div setting-organizations parent-widget="widget" class="part" deferred="::orgDeferred" />
-    <div setting-time-period parent-widget="widget" class="part" deferred="::timePeriodDeferred" hist-params="widget.metadata.hist_parameters" />
 
     <!-- Buttons displayed on the lower  -->
     <div class="bottom-buttons" align="right">
@@ -48,7 +47,9 @@
         <button class="btn btn-sm btn-warning" ng-if="simulationMode" ng-click="saveSimulation()" title="Apply simulation">
           Save
         </button>
+        <div setting-dates-picker class="dates-picker" parent-widget="widget" deferred="::datesPickerDeferred" from="fromDate" to="toDate" period="period" keep-today="keepToday" update-on-pick="true"/>
       </div>
+
     </div>
 
     <div ng-show="widget.demoData" common-data-not-found />

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -49,7 +49,7 @@ angular
               text: 'All'
             }
           ]
-          selected: 2
+          inputEnabled: false
 
 
   class Chart

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -116,12 +116,4 @@ angular
         }, true)
 
       return @hc
-
-    # Private methods
-    # --
-
-    todayIndex = (labels)->
-      projection_date = _.find(labels, (date)-> moment(date) >= moment().startOf('day'))
-      _.indexOf(labels, projection_date)
-
 )


### PR DESCRIPTION
- Uses highstock instead of highchart
- Build labels based on timestamps returned with each series instead of dates strings
- Better zooming capabilities
- Change time period using dates pickers
- Better granularity (use daily intervals)

Goes with https://github.com/maestrano/impac-finance-bolt/pull/44

![voila_capture 2017-09-03_2-30-45_am](https://user-images.githubusercontent.com/9582657/29997174-fad0e47c-904f-11e7-8055-cc6a9426aad8.png)


**TODO**
- [x] Fix threshold tooltip
- [ ] Fix threshold panel appears when using the zoom shortcuts