### PR TITLE
[IMPAC-617] Transactions list in Cash Projection widget

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,11 @@
   "name": "impac-angular",
   "description": "Impac! Front-End Library",
   "version": "1.6.1",
+  "license": "Copyright 2017 Maestrano Pty Ltd",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/maestrano/impac-angular.git"
+  },
   "main": [
     "dist/impac-angular.js",
     "dist/impac-angular.less",
@@ -42,6 +47,11 @@
     "highcharts": "^5.0.11",
     "color": "^3.0.4"
   },
+  "overrides": { 
+    "highcharts": { 
+      "main": "highstock.js" 
+    }
+  },
   "devDependencies": {
     "angular-mocks": "~1.6.0",
     "angular-scenario": "~1.6.0",
@@ -51,11 +61,6 @@
     "angular-translate-handler-log": "~2.14.0",
     "angular-translate-loader-static-files": "^2.14.0",
     "jasmine-jquery": "^2.1.1"
-  },
-  "license": "Copyright 2017 Maestrano Pty Ltd",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/maestrano/impac-angular.git"
   },
   "resolutions": {
     "angular": "~1.6.0"

--- a/src/components/common/transactions-list/transactions-list.component.coffee
+++ b/src/components/common/transactions-list/transactions-list.component.coffee
@@ -1,0 +1,19 @@
+module = angular.module('impac.components.common.transactions-list',[])
+
+module.component('transactionsList', {
+  templateUrl: 'common/transactions-list.tmpl.html'
+  bindings:
+    onHide: '&'
+    onPageChanged: '&'
+    transactions: '<'
+    totalDue: '<'
+    currency: '<'
+    totalRecords: '<'
+  controller: ->
+    ctrl = this
+
+    ctrl.$onInit = ->
+      ctrl.currentPage = 1
+
+    return ctrl
+})

--- a/src/components/common/transactions-list/transactions-list.less
+++ b/src/components/common/transactions-list/transactions-list.less
@@ -1,0 +1,13 @@
+#transactions-list {
+  .top {
+    height: 40px;
+    a.back-link { font-weight: normal; }
+    .pagination { margin: 0px; }
+  }
+
+  .table-container {
+    max-height: ~"calc(@{impac-big-widget-size} - 60px)";
+    overflow: auto;
+    tr.total { font-weight: bold; }
+  }
+}

--- a/src/components/common/transactions-list/transactions-list.tmpl.html
+++ b/src/components/common/transactions-list/transactions-list.tmpl.html
@@ -1,0 +1,38 @@
+<div id="transactions-list">
+  <div class="top">
+    <ul uib-pagination class="pull-right" total-items="$ctrl.totalRecords" ng-model="$ctrl.currentPage" max-size="5" items-per-page="30" class="pagination-sm" force-ellipses="true" ng-change="$ctrl.onPageChanged({page: $ctrl.currentPage})"></ul>
+    <a ng-click="$ctrl.onHide()" class="back-link">
+      <i class="fa fa-chevron-left"></i>
+      Back to chart
+    </a>
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <tr>
+        <th>Code</th>
+        <th>Title</th>
+        <th>Status</th>
+        <th>Transaction date</th>
+        <th>Due date</th>
+        <th class="text-right">Amount</th>
+        <th class="text-right">Balance</th>
+        <th>Rate</th>
+      </tr>
+      <tr ng-repeat="trx in $ctrl.transactions">
+        <td>{{ trx.transaction_number }}</td>
+        <td>{{ trx.title }}</td>
+        <td>{{ trx.status }}</td>
+        <td>{{ trx.transaction_date | date : shortdate }}</td>
+        <td>{{ trx.due_date | date : shortdate }}</td>
+        <td class="text-right">{{ trx.amount | mnoCurrency : trx.currency }}</td>
+        <td class="text-right">{{ trx.balance | mnoCurrency : trx.currency }}</td>
+        <td>{{ trx.currency_rate }}</td>
+      </tr>
+      <tr class="info total">
+        <td colspan="6">TOTAL DUE</td>
+        <td class="text-right">{{ $ctrl.totalDue | mnoCurrency : $ctrl.currency }}</td>
+        <td></td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/src/components/widget/widget.less
+++ b/src/components/widget/widget.less
@@ -46,6 +46,12 @@
       min-height: 250px !important;
       max-height: auto !important;
     }
+
+    // Avoid content to leak out of widget's box
+    .content-template-wrapper {
+      height: 100%;
+      overflow: auto;
+    }
   }
 
   &.pdf-mode .content {

--- a/src/components/widget/widget.tmpl.html
+++ b/src/components/widget/widget.tmpl.html
@@ -21,7 +21,7 @@
     </a>
   </div>
 
-  <div ng-hide="widget.isLoading" ng-include="::templatePath" />
+  <div ng-hide="widget.isLoading" class="content-template-wrapper" ng-include="::templatePath" />
   
   <common-delete-widget ng-if="showDeleteWidget" on-dismiss="toggleDeleteWidget()" on-delete="deleteWidget()" />
 </div>

--- a/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
@@ -70,17 +70,13 @@ module.component('chartThreshold', {
       ctrl.loading = true
       params = targets: {}, metadata: {}
       params.targets[ctrl.kpi.watchables[0]] = [{
-        "#{ctrl.kpiTargetMode}": ctrl.draftTarget.value
+        "#{ctrl.kpiTargetMode}": parseFloat(ctrl.draftTarget.value)
       }]
       return unless ImpacKpisSvc.validateKpiTargets(params.targets)
       promise = if ctrl.isEditingKpi
         ImpacKpisSvc.update(getKpi(), params, false)
       else
-        # TODO: improve the way the hist_params are applied onto widget kpis
-        if ctrl.widget.metadata && (widgetHistParams = ctrl.widget.metadata.hist_parameters)
-          params.metadata.hist_parameters = widgetHistParams
-        else
-          params.metadata.hist_parameters = ImpacUtilities.yearDates()
+        params.metadata.hist_parameters = ctrl.widget.metadata.hist_parameters
         params.widget_id = ctrl.widget.id
         ImpacKpisSvc.create('impac', ctrl.kpi.endpoint, ctrl.kpi.watchables[0], params)
       promise.then(
@@ -126,15 +122,15 @@ module.component('chartThreshold', {
     onChartClick = (event)->
       # Check whether click event fired is from the 'reset zoom' button
       return if event.srcElement.textContent == 'Reset zoom'
-      # Gaurd for tooltips / other chart areas that don't return a yAxis value
+      # Guard for tooltips / other chart areas that don't return a yAxis value
       return unless event.yAxis && event.yAxis[0]
       value = event.yAxis[0].value
-      # Gaurd for click events fired outside of the yAxis values range
+      # Guard for click events fired outside of the yAxis values range
       if !value || _.isNaN(value) then return else value = value.toFixed(2)
       ctrl.createKpi(value)
 
     onThresholdClick = (thresholdSerie)->
-      thresholdValue = (opts = thresholdSerie.options).data[opts.data.length - 1]
+      thresholdValue = (opts = thresholdSerie.options).data[opts.data.length - 1][1].toFixed(2)
       ctrl.editKpi(kpiId: opts.kpiId, value: thresholdValue)
 
     disableAttachability = (logMsg)->
@@ -165,7 +161,7 @@ module.component('chartThreshold', {
       widgetHistParams = ctrl.widget.metadata && ctrl.widget.metadata.hist_parameters
       # Widget histParams are YTD by default (when undefined on metadata),
       # therefore in the past by default
-      ctrl.disabled = _.isEmpty(widgetHistParams) || moment(widgetHistParams.to) <= moment().startOf('day')
+      ctrl.disabled = widgetHistParams? && moment(widgetHistParams.to) <= moment.utc().startOf('day')
       return
 
     return ctrl

--- a/src/components/widgets-common/chart-threshold/chart-threshold.less
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.less
@@ -40,7 +40,14 @@ chart-threshold {
     }
 
     & > .btn.has-spinner {
-      i { padding: 0 15px; }
+      outline: none;
+      i {
+        padding: 0 15px;
+        outline: none;
+      }
+      span {
+        outline: none;
+      }
     }
   }
 }

--- a/src/components/widgets-settings/dates-picker/dates-picker.directive.coffee
+++ b/src/components/widgets-settings/dates-picker/dates-picker.directive.coffee
@@ -16,6 +16,7 @@ module.directive('settingDatesPicker', ($templateCache, $filter, ImpacWidgetsSvc
       minDate: '=?'
       updateOnPick: '=?'
       template: '=?'
+      period: '=?'
     },
     template: $templateCache.get('widgets-settings/dates-picker.tmpl.html'),
 
@@ -112,7 +113,7 @@ module.directive('settingDatesPicker', ($templateCache, $filter, ImpacWidgetsSvc
           hist_parameters:
             from: $filter('date')(scope.calendarFrom.value, 'yyyy-MM-dd')
             to: $filter('date')(scope.calendarTo.value, 'yyyy-MM-dd')
-            period: "RANGE"
+            period: scope.period || "RANGE"
             keep_today: isToToday()
         }
 

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
@@ -6,12 +6,18 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
   # Define settings
   # --------------------------------------
   $scope.orgDeferred = $q.defer()
-  $scope.timePeriodDeferred = $q.defer()
+  $scope.datesPickerDeferred = $q.defer()
 
   settingsPromises = [
     $scope.orgDeferred.promise,
-    $scope.timePeriodDeferred.promise
+    $scope.datesPickerDeferred.promise
   ]
+
+  # Dates picker defaults
+  $scope.fromDate = moment().subtract(3, 'months').format('YYYY-MM-DD')
+  $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
+  $scope.period = 'DAILY'
+  $scope.keepToday = false
 
   # Widget specific methods
   # --------------------------------------
@@ -25,6 +31,10 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
     # chartColors = ImpacTheming.get().chartColors
     # Set chart accounts series colors by account bias ('positive' / 'negative')
     setSeriesColors(w.content.chart.series, { positive: '#3FC4FF', negative: '#e50228'})
+
+    if hist = w.metadata.hist_parameters
+      $scope.fromDate = hist.from
+      $scope.toDate = hist.to
 
   $scope.legendItemOnClick = (account)->
     serie = $scope.chart? && $scope.chart.hc? && getSerieByAccount($scope.chart.hc.series, account)

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
@@ -4,12 +4,11 @@
   .data-container {
     height: ~"calc(@{impac-big-widget-size} - 20px)";
     width: 100%;
-    display: flex;
   }
 
   .left-panel {
-    flex: 0;
-    min-width: 180px;
+    width: 180px;
+    display: inline-block;
     overflow: auto;
   }
 
@@ -43,19 +42,12 @@
   }
 
   .right-panel {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    position: relative;
-
-    .top-bar {
-      flex: 0;
-      min-height: 50px;
-    }
+    width: ~"calc(100% - 180px)";
+    float: right;
 
     // Highchart container
     .cash-balance-chart {
-      flex: 1;
+      height: ~"calc(@{impac-big-widget-size} - 50px)";
     }
   }
 }

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.less
@@ -2,7 +2,7 @@
   .tall-widget();
 
   .data-container {
-    height: ~"calc(@{impac-big-widget-size} - 20px)";
+    height: ~"calc(@{impac-big-widget-size} - 50px)";
     width: 100%;
   }
 
@@ -49,5 +49,11 @@
     .cash-balance-chart {
       height: ~"calc(@{impac-big-widget-size} - 50px)";
     }
+  }
+
+  .dates-picker {
+    display: inline-block;
+    float: right;
+    font-size: 12px;
   }
 }

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
@@ -35,7 +35,6 @@
         </div>
       </div>
       <div class="right-panel">
-        <div class="top-bar"></div>
         <div id="{{chartId()}}" class="cash-balance-chart"></div>
       </div>
     </div>

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
@@ -7,7 +7,6 @@
     <h4>Widget settings</h4>
 
     <div setting-organizations parent-widget="widget" class="part" deferred="::orgDeferred" />
-    <div setting-time-period parent-widget="widget" class="part" deferred="::timePeriodDeferred" hist-params="widget.metadata.hist_parameters" />
 
     <!-- Buttons displayed on the lower  -->
     <div class="bottom-buttons" align="right">
@@ -38,6 +37,8 @@
         <div id="{{chartId()}}" class="cash-balance-chart"></div>
       </div>
     </div>
+
+    <div setting-dates-picker class="dates-picker" parent-widget="widget" deferred="::datesPickerDeferred" from="fromDate" to="toDate" period="period" keep-today="keepToday" update-on-pick="true"/>
 
     <div ng-show="widget.demoData" common-data-not-found />
   </div>

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -69,8 +69,13 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       $scope.fromDate = hist.from
       $scope.toDate = hist.to
 
+  legendFormatter = ->
+    series = this
+    imgSrc = ImpacAssets.get(_.camelCase(series.name + 'LegendIcon'))
+    "<img src='#{imgSrc}'><br>  #{series.name}"
 
   w.format = ->
+    # Chart basic options
     options =
       chartType: 'line'
       currency: w.metadata.currency
@@ -79,20 +84,11 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       thresholds: getThresholds()
 
     $scope.chart ||= new HighchartsFactory($scope.chartId(), w.content.chart, options)
-    # Extend default chart formatters to add custom legend img icon
-    defaultFormattersConfig = $scope.chart.formatters()
-    $scope.chart.formatters = ->
-      angular.merge(defaultFormattersConfig, {
-        legend:
-          useHTML: true
-          labelFormatter: ->
-            name = this.name
-            imgSrc = ImpacAssets.get(_.camelCase(name + 'LegendIcon'))
-            img = "<img src='#{imgSrc}'><br>"
-            return img + '	' + name
-      })
-
     $scope.chart.render(w.content.chart, options)
+
+    # Chart customization
+    $scope.chart.addCustomLegend(legendFormatter)
+
     $scope.chartDeferred.notify($scope.chart.hc)
 
   $scope.chartId = ->

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -63,7 +63,6 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     options =
       chartType: 'line'
       currency: w.metadata.currency
-      period: getPeriod()
       showToday: true
       showLegend: true
       thresholds: getThresholds()

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -69,6 +69,16 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       $scope.fromDate = hist.from
       $scope.toDate = hist.to
 
+
+  # Sets the transactions list resources type and displays it
+  onClickBar = (event) ->
+    series = this
+    resources = switch(series.name)
+      when 'Payables'
+        'bills'
+      when 'Receivables'
+        'invoices'
+    return unless resources?
   legendFormatter = ->
     series = this
     imgSrc = ImpacAssets.get(_.camelCase(series.name + 'LegendIcon'))
@@ -88,6 +98,7 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
 
     # Chart customization
     $scope.chart.addCustomLegend(legendFormatter)
+    $scope.chart.addSeriesEvent('click', onClickBar)
 
     $scope.chartDeferred.notify($scope.chart.hc)
 

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -41,8 +41,9 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     $scope.isDataFound = w.content?
 
     # Offset will be applied to all intervals after today
-    todayInterval = w.content.chart.series[0].zones[0].value
-    $scope.intervalsCount = w.content.chart.labels.length - todayInterval
+    todayInterval = _.findIndex w.content.chart.series[0].data, (vector) ->
+      vector[0] >= moment.now()
+    $scope.intervalsCount = w.content.chart.series[0].data.length - todayInterval
 
     projectedSerie = _.find w.content.chart.series, (serie) ->
       serie.name == "Projected cash"

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -1,5 +1,5 @@
 module = angular.module('impac.components.widgets.accounts-cash-projection', [])
-module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, ImpacKpisSvc, ImpacAssets, HighchartsFactory) ->
+module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, ImpacKpisSvc, ImpacAssets, HighchartsFactory, BoltResources) ->
 
   w = $scope.widget
 
@@ -33,6 +33,31 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
   $scope.period = 'DAILY'
   $scope.keepToday = false
+
+  # Transactions List component
+  $scope.trxList = { display: false }
+
+  $scope.trxList.show = ->
+    $scope.trxList.display = true
+
+  $scope.trxList.hide = ->
+    $scope.trxList.display = false
+
+  $scope.trxList.fetch = (currentPage = 1) ->
+    params = angular.merge(
+      $scope.trxList.params, {
+        metadata: _.pick(w.metadata, 'organization_ids')
+        page:
+          number: currentPage
+      }
+    )
+    BoltResources.index(w.metadata.bolt_path, $scope.trxList.resources, params).then(
+      (response) ->
+        # Update trxList object with dynamic values
+        $scope.trxList.transactions = _.map(response.data.data, (trx) -> trx.attributes)
+        $scope.trxList.totalRecords = response.data.meta.record_count
+    )
+
 
   # Widget specific methods
   # --------------------------------------
@@ -69,6 +94,9 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       $scope.fromDate = hist.from
       $scope.toDate = hist.to
 
+  dateFilter = (timestamp) ->
+    pickedDate = moment.unix(timestamp / 1000).format('YYYY-MM-DD')
+    if pickedDate == moment().format('YYYY-MM-DD') then "lte #{pickedDate}" else pickedDate
 
   # Sets the transactions list resources type and displays it
   onClickBar = (event) ->
@@ -79,6 +107,17 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       when 'Receivables'
         'invoices'
     return unless resources?
+
+    # Init trxList object with static values
+    $scope.trxList.resources = resources
+    $scope.trxList.totalDue = event.point.y
+    $scope.trxList.params = {
+      filter:
+        due_date: dateFilter(event.point.x)
+        status: ['AUTHORISED', 'APPROVED', 'SUBMITTED']
+    }
+    $scope.trxList.fetch().finally(-> $scope.trxList.show())
+
   legendFormatter = ->
     series = this
     imgSrc = ImpacAssets.get(_.camelCase(series.name + 'LegendIcon'))

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -6,13 +6,13 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   # Define settings
   # --------------------------------------
   $scope.orgDeferred = $q.defer()
-  $scope.timePeriodDeferred = $q.defer()
+  $scope.datesPickerDeferred = $q.defer()
   $scope.intervalsOffsetsDeferred = $q.defer()
   $scope.currentOffsetsDeferred = $q.defer()
 
   settingsPromises = [
     $scope.orgDeferred.promise,
-    $scope.timePeriodDeferred.promise,
+    $scope.datesPickerDeferred.promise,
     $scope.intervalsOffsetsDeferred.promise,
     $scope.currentOffsetsDeferred.promise
   ]
@@ -27,6 +27,12 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   $scope.chartThresholdOptions = {
     label: 'Get alerted when the cash projection goes below'
   }
+
+  # Dates picker defaults
+  $scope.fromDate = moment().subtract(3, 'months').format('YYYY-MM-DD')
+  $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
+  $scope.period = 'DAILY'
+  $scope.keepToday = false
 
   # Widget specific methods
   # --------------------------------------
@@ -57,6 +63,10 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
       $scope.currentProjectedCash = projectedSerie.data[todayInterval] - totalOffset
 
     $scope.isTimePeriodInThePast = w.metadata.hist_parameters && moment(w.metadata.hist_parameters.to) < moment().startOf('day')
+
+    if hist = w.metadata.hist_parameters
+      $scope.fromDate = hist.from
+      $scope.toDate = hist.to
 
 
   w.format = ->

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -41,6 +41,11 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     projectedSerie = _.find w.content.chart.series, (serie) ->
       serie.name == "Projected cash"
 
+    cashFlowSerie = _.find w.content.chart.series, (serie) ->
+      serie.name == "Cash flow"
+    cashFlowSerie.data = []
+    cashFlowSerie.type = 'area'
+
     totalOffset = 0.0
     if w.metadata.offset && w.metadata.offset.current && w.metadata.offset.current.length > 0
       totalOffset += _.sum(w.metadata.offset.current)

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.less
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.less
@@ -59,4 +59,8 @@
     float: right;
     font-size: 12px;
   }
+
+  transactions-list {
+    font-size: 12px;
+  }
 }

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.less
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.less
@@ -6,7 +6,6 @@
   }
 
   .highcharts-legend-item {
-
     rect.highcharts-point {
       display: none;
     }
@@ -53,5 +52,11 @@
       font-size: 20px;
       margin-top: 0px;
     }
+  }
+
+  .dates-picker {
+    display: inline-block;
+    float: right;
+    font-size: 12px;
   }
 }

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
@@ -4,7 +4,6 @@
     <h4>Widget settings</h4>
 
     <div setting-organizations parent-widget="widget" class="part" deferred="::orgDeferred" />
-    <div setting-time-period parent-widget="widget" class="part" deferred="::timePeriodDeferred" hist-params="widget.metadata.hist_parameters" />
 
     <!-- Buttons displayed on the lower  -->
     <div class="bottom-buttons" align="right">
@@ -48,7 +47,9 @@
         <button class="btn btn-sm btn-warning" ng-if="simulationMode" ng-click="saveSimulation()" title="Apply simulation">
           Save
         </button>
+        <div setting-dates-picker class="dates-picker" parent-widget="widget" deferred="::datesPickerDeferred" from="fromDate" to="toDate" period="period" keep-today="keepToday" update-on-pick="true"/>
       </div>
+
     </div>
 
     <div ng-show="widget.demoData" common-data-not-found />

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
@@ -14,7 +14,11 @@
 
   <!-- Content Panel -->
   <div ng-hide="widget.isEditMode">
-    <div>
+    <!-- Transactions list -->
+    <transactions-list ng-show="trxList.display" on-hide="trxList.hide()" transactions="trxList.transactions" total-due="trxList.totalDue" currency="widget.metadata.currency" total-records="trxList.totalRecords" on-page-changed="trxList.fetch(page)"></transactions-list>
+
+    <!-- Chart -->
+    <div ng-hide="trxList.display">
       <!-- Set KPI target threshold panel -->
       <chart-threshold widget="widget" chart-promise="chartPromise" kpi-create-label="chartThresholdOptions.label" on-complete="widget.format()"></chart-threshold>
 

--- a/src/impac-angular.module.js
+++ b/src/impac-angular.module.js
@@ -165,7 +165,8 @@ angular.module('impac.services',
     'impac.services.alerts',
     'impac.services.notifications',
     'impac.services.events',
-    'impac.services.currency-rates'
+    'impac.services.currency-rates',
+    'impac.services.bolt-resources'
   ]
 );
 /*

--- a/src/impac-angular.module.js
+++ b/src/impac-angular.module.js
@@ -139,7 +139,8 @@ angular.module('impac.components.widgets-common',
 angular.module('impac.components.common',
   [
     'impac.components.common.data-not-found',
-    'impac.components.common.delete-widget'
+    'impac.components.common.delete-widget',
+    'impac.components.common.transactions-list'
   ]
 );
 /*

--- a/src/services/bolt-resources/bolt-resources.svc.coffee
+++ b/src/services/bolt-resources/bolt-resources.svc.coffee
@@ -1,0 +1,19 @@
+angular
+.module('impac.services.bolt-resources', [])
+.service('BoltResources', ($http, ImpacMainSvc) ->
+
+  authHeaders = ->
+    auth = 'Basic ' + btoa(ImpacMainSvc.getSsoSessionId())
+    { 'Authorization': auth }
+
+  buildUrl = (pathArray, paramsHash) ->
+    url = pathArray.join('/')
+    params = decodeURIComponent( $.param(paramsHash) )
+    [url, params].join('?')
+
+  @index = (boltPath, resourcesName, params) ->
+    url = buildUrl([boltPath, resourcesName], params)
+    $http.get(url, { headers: authHeaders() })
+
+  return
+)

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -49,7 +49,7 @@ angular
               text: 'All'
             }
           ]
-          selected: 2
+          inputEnabled: false
 
 
   class Chart

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -116,12 +116,4 @@ angular
         }, true)
 
       return @hc
-
-    # Private methods
-    # --
-
-    todayIndex = (labels)->
-      projection_date = _.find(labels, (date)-> moment(date) >= moment().startOf('day'))
-      _.indexOf(labels, projection_date)
-
 )

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -123,4 +123,16 @@ angular
         useHTML: useHTML
         labelFormatter: formatterCallback
       }, true)
+
+    # Adds events to series objects
+    addSeriesEvent: (eventName, callback) ->
+      return if _.isEmpty(@hc)
+      eventHash = {}
+      eventHash[eventName] = callback
+      @hc.update({
+        plotOptions:
+          series:
+            events: eventHash
+      })
+      return @hc
 )

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -116,4 +116,11 @@ angular
         }, true)
 
       return @hc
+
+    # Extend default chart formatters to add custom legend img icon
+    addCustomLegend: (formatterCallback, useHTML = true) ->
+      @hc.legend.update({
+        useHTML: useHTML
+        labelFormatter: formatterCallback
+      }, true)
 )

--- a/src/stylesheets/globals.less
+++ b/src/stylesheets/globals.less
@@ -86,7 +86,6 @@ body {
   }
 
   .widget-item .content, kpis-bar .kpi {
-
     ::-webkit-scrollbar {
       width: 6px;
       background-color: transparent;


### PR DESCRIPTION
**Note** check only changes from #fda28a3 as feature/cash-trx-list branches off feature/time-management which is not merged yet

- New BoltResources service to query the Bolt's json api
- New component to display transactions list with pagination
- Displays transactions details when the user clicks on a bar (shows bills when click on "Payables", invoices when click on "Receivables")

![voila_capture 2017-09-05_10-35-24_pm](https://user-images.githubusercontent.com/9582657/30061404-8d46f5e4-928a-11e7-96cb-2925d66c5a57.png)

@alexnoox feel free to have a look if you wish ;)

**Dependencies**
- https://github.com/maestrano/impac/pull/497
- https://github.com/maestrano/impac-finance-bolt/pull/45