### PR TITLE
[IMPAC-667] Update time management on cashflow widgets

### DIFF
--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.directive.coffee
@@ -6,18 +6,8 @@ module.controller('WidgetAccountsCashBalanceCtrl', ($scope, $q, $timeout, $filte
   # Define settings
   # --------------------------------------
   $scope.orgDeferred = $q.defer()
-  $scope.datesPickerDeferred = $q.defer()
 
-  settingsPromises = [
-    $scope.orgDeferred.promise,
-    $scope.datesPickerDeferred.promise
-  ]
-
-  # Dates picker defaults
-  $scope.fromDate = moment().subtract(3, 'months').format('YYYY-MM-DD')
-  $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
-  $scope.period = 'DAILY'
-  $scope.keepToday = false
+  settingsPromises = [$scope.orgDeferred.promise]
 
   # Widget specific methods
   # --------------------------------------

--- a/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
+++ b/src/components/widgets/accounts-cash-balance/accounts-cash-balance.tmpl.html
@@ -38,8 +38,6 @@
       </div>
     </div>
 
-    <div setting-dates-picker class="dates-picker" parent-widget="widget" deferred="::datesPickerDeferred" from="fromDate" to="toDate" period="period" keep-today="keepToday" update-on-pick="true"/>
-
     <div ng-show="widget.demoData" common-data-not-found />
   </div>
 </div>

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -6,13 +6,11 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   # Define settings
   # --------------------------------------
   $scope.orgDeferred = $q.defer()
-  $scope.datesPickerDeferred = $q.defer()
   $scope.intervalsOffsetsDeferred = $q.defer()
   $scope.currentOffsetsDeferred = $q.defer()
 
   settingsPromises = [
     $scope.orgDeferred.promise,
-    $scope.datesPickerDeferred.promise,
     $scope.intervalsOffsetsDeferred.promise,
     $scope.currentOffsetsDeferred.promise
   ]
@@ -27,12 +25,6 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
   $scope.chartThresholdOptions = {
     label: 'Get alerted when the cash projection goes below'
   }
-
-  # Dates picker defaults
-  $scope.fromDate = moment().subtract(3, 'months').format('YYYY-MM-DD')
-  $scope.toDate = moment().add(1, 'month').format('YYYY-MM-DD')
-  $scope.period = 'DAILY'
-  $scope.keepToday = false
 
   # Transactions List component
   $scope.trxList = { display: false }

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.tmpl.html
@@ -51,7 +51,6 @@
         <button class="btn btn-sm btn-warning" ng-if="simulationMode" ng-click="saveSimulation()" title="Apply simulation">
           Save
         </button>
-        <div setting-dates-picker class="dates-picker" parent-widget="widget" deferred="::datesPickerDeferred" from="fromDate" to="toDate" period="period" keep-today="keepToday" update-on-pick="true"/>
       </div>
 
     </div>

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -24,13 +24,14 @@ angular
         series: series
         rangeSelector:
           buttons: [
+            { type: 'month', count: 4, text: 'def.' },
             { type: 'month', count: 1, text: '1m' },
             { type: 'month', count: 3, text: '3m' },
             { type: 'month', count: 6, text: '6m' },
             { type: 'year', count: 1, text: '1y' },
             { type: 'all', text: 'All' }
           ]
-          inputEnabled: false
+          selected: 0
 
   class Chart
     constructor: (@id, @data = {}, @options = {})->


### PR DESCRIPTION
After this change, the user won't be able to modify the time period on the cashflow widgets, but only to change the zooming instead.

Depends on https://github.com/maestrano/impac-finance-bolt/pull/51