### PR TITLE
[BUG] Change overflow attr to auto

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### v1.5.8 | 2017 - Week 39
 
 #### Fixes
+- Change overflow attribute to auto for widget selector (IE11)
 
 -------------------------------------------------------------
 
@@ -122,7 +123,7 @@ dhbConfig: {
 - Template for Cash Projection widget
 - Component for chart-threshold setting
 - Attach threshold KPI to Cash Projection chart
-- Adds a HighchartsFactory for creating & updating highchart objects 
+- Adds a HighchartsFactory for creating & updating highchart objects
 
 #### Fixes
 - Settings Time Slider not displaying range period label
@@ -228,7 +229,7 @@ translateSettings: {
 
 -------------------------------------------------------------
 
-### v1.4.11 | 2017 - Week 17 
+### v1.4.11 | 2017 - Week 17
 
 #### Adds
 - Apply widget settings on custom calc modal proceed (save)
@@ -284,8 +285,8 @@ translateSettings: {
 ### v1.4.8 | Week 4
 
 #### Adds
-- [IMPAC-331] KPIs display layout labels and current value on first add 
-- [IMPAC-335] Alerts can have multiple recipients 
+- [IMPAC-331] KPIs display layout labels and current value on first add
+- [IMPAC-335] Alerts can have multiple recipients
 - [IMPAC-162] Add time period setting to Accounts Comparison
 - [IMPAC-466] Add time period setting to Custom Calculation
 - [IMPAC-467] Add time period setting to Accounts Classes Comparison

--- a/src/components/dashboard/dashboard.less
+++ b/src/components/dashboard/dashboard.less
@@ -115,7 +115,7 @@
 
     .section-lines {
       overflow-x: hidden;
-      overflow-y: scroll;
+      overflow-y: auto;
       height: 200px;
       margin-right: -10px;
       margin-left: 0px;


### PR DESCRIPTION
@cesar-tonnoir @xaun This PR changes the overflow attr for the widget selector to auto. This is so that the scrollbar doesn't appear anymore on IE11 as it makes it seem as if the selector is too long and overflowing out of the menu. Will leave additional comments on JIRA as I cannot link the ticket here directly. Please review. :) 