### PR TITLE
[IMPAC-663] Fix unwanted triggering of create threshold panel

### DIFF
--- a/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
@@ -121,7 +121,7 @@ module.component('chartThreshold', {
     onChartNotify = (chart)->
       ctrl.chart = chart
       return unless validateHistParameters()
-      Highcharts.addEvent(chart.hc.container, 'click', onChartClick)
+      ctrl.chart.options.chartOnClickCallbacks.push(onChartClick)
       _.each buildThresholdsFromKpis(), (threshold)->
         thresholdSerie = ctrl.chart.findThreshold(threshold.kpiId)
         thresholdSerie = ctrl.chart.addThreshold(threshold) unless thresholdSerie?
@@ -129,12 +129,7 @@ module.component('chartThreshold', {
       return
 
     onChartClick = (event)->
-      # Check whether click event fired is from the 'reset zoom' button
-      return if event.srcElement.textContent == 'Reset zoom'
-      # Guard for tooltips / other chart areas that don't return a yAxis value
-      return unless event.yAxis && event.yAxis[0]
-      value = event.yAxis[0].value
-      # Guard for click events fired outside of the yAxis values range
+      value = event.yAxis && event.yAxis[0] && event.yAxis[0].value
       if !value || _.isNaN(value) then return else value = value.toFixed(2)
       ctrl.createKpi(value)
 

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -121,6 +121,7 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, Impa
     # Chart basic options
     options =
       chartType: 'line'
+      chartOnClickCallbacks: []
       currency: w.metadata.currency
       showToday: true
       showLegend: true

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -9,6 +9,8 @@ angular
           type: 'line'
           zoomType: 'x'
           spacingTop: 20
+          events:
+            click: (event)-> _.each(_.get(options, 'chartOnClickCallbacks', []), (cb)-> cb(event))
         title: null
         credits:
           enabled: false
@@ -133,5 +135,5 @@ angular
           series:
             events: eventHash
       })
-      return @hc
+      @hc
 )


### PR DESCRIPTION
Some things to note:
- `Highcharts.addEvent(chart.hc.container, 'click', onChartClick)` applies the click event to the whole canvas, causing the need for the existing (incomplete) guarding in the `onChartClick` callback method. 
- The native `chart.events.click` callback only triggers on chart clicks. Fixing the problem of needing to guard for things like legend, zoom bar, etc clicks.
- The native `chart.events.click` callback can not be updated after render. 