### PR TITLE
[IMPAC-665] Sync status on dashboard

### DIFF
--- a/src/components/dashboard-settings/sync-apps/sync-apps.directive.js.coffee
+++ b/src/components/dashboard-settings/sync-apps/sync-apps.directive.js.coffee
@@ -58,6 +58,7 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
       # Returns the formatted timezone offset for date display purpose
       processAppInstancesSync = (responseData) ->
         scope.connectors = angular.copy(responseData.connectors) || []
+        scope.has_running_cube = responseData.has_running_cube || false
         scope.realtimeSyncing = scope.connectors.length == 0
 
         wasSyncing = scope.isSyncing
@@ -65,6 +66,8 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
           c.status == "PENDING" || c.status == "RUNNING"
         )
         scope.hasError = scope.connectors && scope.connectors.length > 0 && _.any(scope.connectors, (c) -> isError(c))
+
+        scope.has_running_apps = scope.connectors.length > 0 && scope.has_running_cube
 
         for connector in scope.connectors
           formatDate(connector)

--- a/src/components/dashboard-settings/sync-apps/sync-apps.directive.js.coffee
+++ b/src/components/dashboard-settings/sync-apps/sync-apps.directive.js.coffee
@@ -12,7 +12,7 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
       # Variables initialization
       #====================================
       scope.isSyncing = false
-      scope.realtimeSyncing = false
+      scope.has_connector = false
       scope.hasError = false
       scope.modalOpened = false
       # unused?
@@ -67,7 +67,8 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
         )
         scope.hasError = scope.connectors && scope.connectors.length > 0 && _.any(scope.connectors, (c) -> isError(c))
 
-        scope.has_running_apps = scope.connectors.length > 0 && scope.has_running_cube
+        scope.has_connectors = scope.connectors.length > 0
+        scope.has_running_apps = scope.has_connectors || scope.has_running_cube
 
         for connector in scope.connectors
           formatDate(connector)

--- a/src/components/dashboard-settings/sync-apps/sync-apps.directive.js.coffee
+++ b/src/components/dashboard-settings/sync-apps/sync-apps.directive.js.coffee
@@ -12,7 +12,7 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
       # Variables initialization
       #====================================
       scope.isSyncing = false
-      scope.has_connector = false
+      scope.hasConnector = false
       scope.hasError = false
       scope.modalOpened = false
       # unused?
@@ -58,7 +58,7 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
       # Returns the formatted timezone offset for date display purpose
       processAppInstancesSync = (responseData) ->
         scope.connectors = angular.copy(responseData.connectors) || []
-        scope.has_running_cube = responseData.has_running_cube || false
+        scope.hasRunningCube = responseData.hasRunningCube || false
         scope.realtimeSyncing = scope.connectors.length == 0
 
         wasSyncing = scope.isSyncing
@@ -67,8 +67,8 @@ module.directive('dashboardSettingSyncApps', ($templateCache, $log, $http, $filt
         )
         scope.hasError = scope.connectors && scope.connectors.length > 0 && _.any(scope.connectors, (c) -> isError(c))
 
-        scope.has_connectors = scope.connectors.length > 0
-        scope.has_running_apps = scope.has_connectors || scope.has_running_cube
+        scope.hasConnectors = scope.connectors.length > 0
+        scope.hasRunningApps = scope.hasConnectors || scope.hasRunningCube
 
         for connector in scope.connectors
           formatDate(connector)

--- a/src/components/dashboard-settings/sync-apps/sync-apps.tmpl.html
+++ b/src/components/dashboard-settings/sync-apps/sync-apps.tmpl.html
@@ -4,14 +4,15 @@
   <span class="show-status" uib-popover-template="'connectors.tmpl.html'" popover-trigger="'mouseenter'" popover-placement="bottom" ng-click="triggerSyncAlertsModal()">
     <i class="fa fa-info" ng-click="triggerSyncAlertsModal()" />
     <span class="ng-hide" ng-show="isSyncing" translate>impac.components.sync_apps.syncing</span>
-    <span ng-hide="isSyncing" translate>impac.components.sync_apps.show_sync_status</span>
+    <span ng-hide="isSyncing || !has_running_apps" translate>impac.components.sync_apps.show_sync_status</span>
+    <span class="ng-hide" ng-show="!has_running_apps" translate>impac.components.sync_apps.no_apps_running</span>
   </span>
 
-  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="hasError && !isSyncing">
+  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="(hasError && !isSyncing) || !has_running_apps">
     <i class="fa fa-exclamation-triangle"></i>
   </div>
 
-  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="!hasError && !isSyncing">
+  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="!hasError && !isSyncing && has_running_apps">
     <i class="fa fa-check"></i>
   </div>
 
@@ -23,7 +24,7 @@
 
 <!-- ui.bootstrap popover template -->
 <script type="text/ng-template" id="connectors.tmpl.html">
-  <div class="connector" ng-repeat="connector in connectors track by $index" ng-class="{ '{{connector.status.toLowerCase()}}': true, 'add-seperator': !$last }">
+  <div ng-if="has_running_apps" class="connector" ng-repeat="connector in connectors track by $index" ng-class="{ '{{connector.status.toLowerCase()}}': true, 'add-seperator': !$last }">
     <div class="badge">{{connector.status}}</div>
     <strong>{{connector.name}}</strong> -
     <span ng-switch="connector.status">
@@ -37,7 +38,7 @@
     <!-- <span ng-if="connector.formatted_date"> - Synced at {{connector.formatted_date}}</span> -->
   </div>
   <div class="popover-footer" ng-class="{ 'remove-seperator': realtimeSyncing }">
-    <p>{{'impac.components.sync_apps.all' | translate}} {{realtimeSyncing ? '' : 'other'}} {{'impac.components.sync_apps.applications_are_synced' | translate}}</p>
+    <p ng-show="has_running_cube">{{'impac.components.sync_apps.all' | translate}} {{realtimeSyncing ? '' : 'other'}} {{'impac.components.sync_apps.applications_are_synced' | translate}}</p>
   </div>
 </script>
 

--- a/src/components/dashboard-settings/sync-apps/sync-apps.tmpl.html
+++ b/src/components/dashboard-settings/sync-apps/sync-apps.tmpl.html
@@ -1,14 +1,12 @@
-<!-- Will be displayed only if specified in configuration and if first response has been processed (realtimeSyncing eq true) -->
-<div class="dashboard-settings sync-apps" ng-show="connectors.length || realtimeSyncing">
-
+<!-- Will be displayed only if specified in configuration and if the organizations has running apps -->
+<div class="dashboard-settings sync-apps" ng-show="has_running_apps">
   <span class="show-status" uib-popover-template="'connectors.tmpl.html'" popover-trigger="'mouseenter'" popover-placement="bottom" ng-click="triggerSyncAlertsModal()">
     <i class="fa fa-info" ng-click="triggerSyncAlertsModal()" />
     <span class="ng-hide" ng-show="isSyncing" translate>impac.components.sync_apps.syncing</span>
     <span ng-hide="isSyncing || !has_running_apps" translate>impac.components.sync_apps.show_sync_status</span>
-    <span class="ng-hide" ng-show="!has_running_apps" translate>impac.components.sync_apps.no_apps_running</span>
   </span>
 
-  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="(hasError && !isSyncing) || !has_running_apps">
+  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="(hasError && !isSyncing)">
     <i class="fa fa-exclamation-triangle"></i>
   </div>
 
@@ -16,7 +14,7 @@
     <i class="fa fa-check"></i>
   </div>
 
-  <button id="sync" class="btn btn-primary" ng-click="synchronize()" uib-tooltip="{{'impac.components.sync_apps.tooltip.sync_data' | translate}}" ng-disabled="isSyncing">
+  <button id="sync" class="btn btn-primary" ng-click="synchronize()" uib-tooltip="{{'impac.components.sync_apps.tooltip.sync_data' | translate}}" ng-disabled="isSyncing" ng-show="has_connectors">
     <i class="fa fa-refresh" ng-class="{ 'fa-spin': isSyncing }" />
   </button>
 
@@ -37,8 +35,8 @@
     </span>
     <!-- <span ng-if="connector.formatted_date"> - Synced at {{connector.formatted_date}}</span> -->
   </div>
-  <div class="popover-footer" ng-class="{ 'remove-seperator': realtimeSyncing }">
-    <p ng-show="has_running_cube">{{'impac.components.sync_apps.all' | translate}} {{realtimeSyncing ? '' : 'other'}} {{'impac.components.sync_apps.applications_are_synced' | translate}}</p>
+  <div class="popover-footer" ng-class="{ 'remove-seperator': !has_connectors }" ng-show="has_running_cube">
+    <p>{{'impac.components.sync_apps.all' | translate}} {{has_connectors ? 'other' : ''}} {{'impac.components.sync_apps.applications_are_synced' | translate}}</p>
   </div>
 </script>
 

--- a/src/components/dashboard-settings/sync-apps/sync-apps.tmpl.html
+++ b/src/components/dashboard-settings/sync-apps/sync-apps.tmpl.html
@@ -1,20 +1,20 @@
 <!-- Will be displayed only if specified in configuration and if the organizations has running apps -->
-<div class="dashboard-settings sync-apps" ng-show="has_running_apps">
+<div class="dashboard-settings sync-apps" ng-show="hasRunningApps">
   <span class="show-status" uib-popover-template="'connectors.tmpl.html'" popover-trigger="'mouseenter'" popover-placement="bottom" ng-click="triggerSyncAlertsModal()">
     <i class="fa fa-info" ng-click="triggerSyncAlertsModal()" />
     <span class="ng-hide" ng-show="isSyncing" translate>impac.components.sync_apps.syncing</span>
-    <span ng-hide="isSyncing || !has_running_apps" translate>impac.components.sync_apps.show_sync_status</span>
+    <span ng-hide="isSyncing || !hasRunningApps" translate>impac.components.sync_apps.show_sync_status</span>
   </span>
 
   <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="(hasError && !isSyncing)">
     <i class="fa fa-exclamation-triangle"></i>
   </div>
 
-  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="!hasError && !isSyncing && has_running_apps">
+  <div class="status-btn" ng-click="triggerSyncAlertsModal()" ng-show="!hasError && !isSyncing && hasRunningApps">
     <i class="fa fa-check"></i>
   </div>
 
-  <button id="sync" class="btn btn-primary" ng-click="synchronize()" uib-tooltip="{{'impac.components.sync_apps.tooltip.sync_data' | translate}}" ng-disabled="isSyncing" ng-show="has_connectors">
+  <button id="sync" class="btn btn-primary" ng-click="synchronize()" uib-tooltip="{{'impac.components.sync_apps.tooltip.sync_data' | translate}}" ng-disabled="isSyncing" ng-show="hasConnectors">
     <i class="fa fa-refresh" ng-class="{ 'fa-spin': isSyncing }" />
   </button>
 
@@ -22,7 +22,7 @@
 
 <!-- ui.bootstrap popover template -->
 <script type="text/ng-template" id="connectors.tmpl.html">
-  <div ng-if="has_running_apps" class="connector" ng-repeat="connector in connectors track by $index" ng-class="{ '{{connector.status.toLowerCase()}}': true, 'add-seperator': !$last }">
+  <div ng-if="hasRunningApps" class="connector" ng-repeat="connector in connectors track by $index" ng-class="{ '{{connector.status.toLowerCase()}}': true, 'add-seperator': !$last }">
     <div class="badge">{{connector.status}}</div>
     <strong>{{connector.name}}</strong> -
     <span ng-switch="connector.status">
@@ -35,8 +35,8 @@
     </span>
     <!-- <span ng-if="connector.formatted_date"> - Synced at {{connector.formatted_date}}</span> -->
   </div>
-  <div class="popover-footer" ng-class="{ 'remove-seperator': !has_connectors }" ng-show="has_running_cube">
-    <p>{{'impac.components.sync_apps.all' | translate}} {{has_connectors ? 'other' : ''}} {{'impac.components.sync_apps.applications_are_synced' | translate}}</p>
+  <div class="popover-footer" ng-class="{ 'remove-seperator': !hasConnectors }" ng-show="hasRunningCube">
+    <p>{{'impac.components.sync_apps.all' | translate}} {{hasConnectors ? 'other' : ''}} {{'impac.components.sync_apps.applications_are_synced' | translate}}</p>
   </div>
 </script>
 

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -736,7 +736,6 @@
 
   "impac.components.sync_apps.syncing":                   "Syncing...",
   "impac.components.sync_apps.show_sync_status":          "Show sync status",
-  "impac.components.sync_apps.no_apps_running":           "No apps are running!",
   "impac.components.sync_apps.tooltip.sync_data":         "Sync data and refresh dashboard",
   "impac.components.sync_apps.status.synced_at":          "Synced at",
   "impac.components.sync_apps.status.sync_will_run":      "Sync will run in a few minutes.",

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -736,6 +736,7 @@
 
   "impac.components.sync_apps.syncing":                   "Syncing...",
   "impac.components.sync_apps.show_sync_status":          "Show sync status",
+  "impac.components.sync_apps.no_apps_running":           "No apps are running!",
   "impac.components.sync_apps.tooltip.sync_data":         "Sync data and refresh dashboard",
   "impac.components.sync_apps.status.synced_at":          "Synced at",
   "impac.components.sync_apps.status.sync_will_run":      "Sync will run in a few minutes.",


### PR DESCRIPTION
Only displays 'Sync in real time' when there are cube apps running.
When no apps (at all) are running, displays 'No apps are running!'
/!\ Relies on a new Organization method on the hub, relayed by mno-enterprise.
https://github.com/maestrano/maestrano-hub/pull/802
https://github.com/maestrano/mno-enterprise/pull/567