### PR TITLE
[IMPAC-727] Widget Dates pickers not visible in IE11

### DIFF
--- a/src/filters/moment-date.filter.coffee
+++ b/src/filters/moment-date.filter.coffee
@@ -4,7 +4,7 @@ angular.module('impac.filters.moment-date', []).filter('momentDate', ($translate
     moment.locale($translate.use().toLowerCase())
 
     validPeriods = ['daily', 'weekly', 'monthly', 'quarterly', 'yearly', 'default']
-    if !_.isEmpty(component) && validPeriods.includes(component.toLowerCase())
+    if !_.isEmpty(component) && _.includes(validPeriods, component.toLowerCase())
       component = 'period-' + component.toLowerCase()
 
     settings = ImpacTheming.get()


### PR DESCRIPTION
@cesar-tonnoir @ouranos 
Refactor with lodash for ie11 - fixes dates picker issue

https://maestrano.atlassian.net/browse/IMPAC-727