### PR TITLE
[IMPAC-745] Fixed Cash Projection Crash

### DIFF
--- a/src/components/chart/chart.directive.coffee
+++ b/src/components/chart/chart.directive.coffee
@@ -46,7 +46,7 @@ angular
             $log.error(error)
           (chartData) ->
             userAgent = $window.navigator.userAgent
-            
+
             # Previously, this hack was only for Safari,
             # then we activated it for chrome after release of version 51,
             # now it becomes the default behaviour as IE11 has shown some unstability in the display of charts

--- a/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.component.coffee
@@ -68,6 +68,7 @@ module.component('chartThreshold', {
       return
 
     ctrl.saveKpi = ->
+
       return if ctrl.loading
       ctrl.loading = true
       params = targets: {}, metadata: {}

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -188,51 +188,40 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, $tim
   # Executed after the widget and its settings are initialised and ready
   w.format = ->
     # Instantiate and render chart
+    legendOptions =
+      legend:
+        useHTML: true
+        labelFormatter: legendFormatter
 
-    options = highChartsSettings()
+    callBackOptions =
+      chartOnClickCallbacks: []
+      plotOptions:
+        series:
+          events:
+            click: onClickBar
+            legendItemClick: onClickLegend
+
+    formattingOptions =
+      chartType: 'line'
+      currency: w.metadata.currency
+      showToday: true
+      showLegend: true
+      withZooming:
+        defaults: w.metadata.xAxis
+        callback: onZoom
+
+    options = angular.merge(legendOptions, callBackOptions, formattingOptions)
+
     $scope.chart ||= new HighchartsFactory($scope.chartId(), w.content.chart, options)
+
     $scope.chart.render(w.content.chart, options)
 
-    # Add events callbacks to chart object
-    $scope.chart.addCustomLegend(legendFormatter)
-    # $scope.chart.addSeriesEvent('click', onClickBar)
-    # $scope.chart.addSeriesEvent('legendItemClick', onClickLegend)
-
-    # Notifies parent element that the chart is ready to be displayed
-    # debugger;
     $scope.chartDeferred.notify($scope.chart)
-    debugger;
+    # Notifies parent element that the chart is ready to be displayed
+
 
   $scope.widgetDeferred.resolve(settingsPromises)
 )
-
-highChartsSettings =->
-  formattingOptions =
-    legend:
-      useHTML: true
-      labelFormatter: legendFormatter
-
-  callBackOptions =
-    chartOnClickCallbacks: []
-    plotOptions:
-      series:
-        events:
-          click: onClickBar
-          legendItemClick: onClickLegend
-
-  formattingOptions =
-    chartType: 'line'
-    currency: w.metadata.currency
-    showToday: true
-    showLegend: true
-    withZooming:
-      defaults: w.metadata.xAxis
-      callback: onZoom
-
-  return angular.merge(formattingOptions, callBackOptions, formattingOptions)
-
-
-
 
 module.directive('widgetAccountsCashProjection', ->
   return {

--- a/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -107,7 +107,7 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, $tim
     display: false
     show: -> this.display = true
     hide: -> this.display = false
-  
+
   $scope.addForecastPopup.createTransaction = (trx) ->
     BoltResources.create(
       w.metadata.bolt_path,
@@ -188,29 +188,51 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, $tim
   # Executed after the widget and its settings are initialised and ready
   w.format = ->
     # Instantiate and render chart
-    options =
-      chartType: 'line'
-      chartOnClickCallbacks: []
-      currency: w.metadata.currency
-      showToday: true
-      showLegend: true
-      withZooming:
-        defaults: w.metadata.xAxis
-        callback: onZoom
 
+    options = highChartsSettings()
     $scope.chart ||= new HighchartsFactory($scope.chartId(), w.content.chart, options)
     $scope.chart.render(w.content.chart, options)
 
     # Add events callbacks to chart object
     $scope.chart.addCustomLegend(legendFormatter)
-    $scope.chart.addSeriesEvent('click', onClickBar)
-    $scope.chart.addSeriesEvent('legendItemClick', onClickLegend)
+    # $scope.chart.addSeriesEvent('click', onClickBar)
+    # $scope.chart.addSeriesEvent('legendItemClick', onClickLegend)
 
     # Notifies parent element that the chart is ready to be displayed
+    # debugger;
     $scope.chartDeferred.notify($scope.chart)
+    debugger;
 
   $scope.widgetDeferred.resolve(settingsPromises)
 )
+
+highChartsSettings =->
+  formattingOptions =
+    legend:
+      useHTML: true
+      labelFormatter: legendFormatter
+
+  callBackOptions =
+    chartOnClickCallbacks: []
+    plotOptions:
+      series:
+        events:
+          click: onClickBar
+          legendItemClick: onClickLegend
+
+  formattingOptions =
+    chartType: 'line'
+    currency: w.metadata.currency
+    showToday: true
+    showLegend: true
+    withZooming:
+      defaults: w.metadata.xAxis
+      callback: onZoom
+
+  return angular.merge(formattingOptions, callBackOptions, formattingOptions)
+
+
+
 
 module.directive('widgetAccountsCashProjection', ->
   return {

--- a/src/components/widgets/accounts-class-comparison/accounts-class-comparison.directive.coffee
+++ b/src/components/widgets/accounts-class-comparison/accounts-class-comparison.directive.coffee
@@ -35,7 +35,6 @@ module.controller('WidgetAccountsClassComparisonCtrl', ($scope, $q, $filter, Cha
   w.initContext = ->
     $scope.isDataFound = angular.isDefined(w.content) && !_.isEmpty(w.content.summary) && !_.isEmpty(w.content.companies)
     if $scope.isDataFound
-      $scope.timePeriodInfoParams.histParams = w.metadata && w.metadata.hist_parameters
       $scope.classifications = _.map(w.content.summary, (summary) ->
         klass = summary.classification
         {

--- a/src/components/widgets/accounts-class-comparison/accounts-class-comparison.directive.coffee
+++ b/src/components/widgets/accounts-class-comparison/accounts-class-comparison.directive.coffee
@@ -34,7 +34,10 @@ module.controller('WidgetAccountsClassComparisonCtrl', ($scope, $q, $filter, Cha
 
   w.initContext = ->
     $scope.isDataFound = angular.isDefined(w.content) && !_.isEmpty(w.content.summary) && !_.isEmpty(w.content.companies)
+    debugger;
     if $scope.isDataFound
+      debugger;
+      $scope.timePeriodInfoParams.histParams = w.metadata && w.metadata.hist_parameters
       $scope.classifications = _.map(w.content.summary, (summary) ->
         klass = summary.classification
         {

--- a/src/components/widgets/accounts-class-comparison/accounts-class-comparison.directive.coffee
+++ b/src/components/widgets/accounts-class-comparison/accounts-class-comparison.directive.coffee
@@ -34,9 +34,7 @@ module.controller('WidgetAccountsClassComparisonCtrl', ($scope, $q, $filter, Cha
 
   w.initContext = ->
     $scope.isDataFound = angular.isDefined(w.content) && !_.isEmpty(w.content.summary) && !_.isEmpty(w.content.companies)
-    debugger;
     if $scope.isDataFound
-      debugger;
       $scope.timePeriodInfoParams.histParams = w.metadata && w.metadata.hist_parameters
       $scope.classifications = _.map(w.content.summary, (summary) ->
         klass = summary.classification

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -23,6 +23,9 @@ angular
         title: null
         credits:
           enabled: false
+        plotOptions:
+          series:
+            animation: false
         legend:
           enabled: _.get(options, 'showLegend', true)
           layout: 'vertical'
@@ -52,6 +55,9 @@ angular
       @_template = templates[@options.chartType]
       return
 
+    update: (data) ->
+      @hc.update(data)
+
     render: (data, options)->
       @data = data if _.isObject(data)
       angular.extend(@options, options)
@@ -59,7 +65,8 @@ angular
       if _.isEmpty(@hc)
         @hc = Highcharts.stockChart(@id, chartConfig)
       else
-        @hc.update(chartConfig)
+          # @hc.update(chartConfig)
+        @hc = Highcharts.stockChart(@id, chartConfig)
       return @
 
     template: ->
@@ -132,13 +139,17 @@ angular
 
     # Extend default chart formatters to add custom legend img icon
     addCustomLegend: (formatterCallback, useHTML = true) ->
-      @hc.legend.update({
+    #   @hc.legend.update({
+    #     useHTML: useHTML
+    #     labelFormatter: formatterCallback
+    #   })
+      return {
         useHTML: useHTML
         labelFormatter: formatterCallback
-      })
+      }
 
     # Adds events to series objects
-    addSeriesEvent: (eventName, callback) ->
+    addSeriesEvent: (eventNames, callback) ->
       return if _.isEmpty(@hc)
       eventHash = {}
       eventHash[eventName] = callback
@@ -146,6 +157,11 @@ angular
         plotOptions:
           series:
             events: eventHash
+            animation: false
       })
-      @hc
+      # @hc
+      # return if _.isEmpty(@hc)
+      # _.forEach(eventNames, (eventName) -> {
+      #   existingEvents
+      # })
 )

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -5,9 +5,6 @@ angular
   templates =
     line: Object.freeze
       get: (series = [], options = {})->
-        seriesEvents = if options.plotOptions then options.plotOptions.series.events else {}
-        useHTML = if options.legend then options.legend.useHTML else false
-        labelFormatter = if options.legend then options.legend.labelFormatter else false
 
         zoomingOptions = _.get(options, 'withZooming')
         xAxisOptions = if zoomingOptions?
@@ -25,7 +22,7 @@ angular
             click: (event)-> _.each(_.get(options, 'chartOnClickCallbacks', []), (cb)-> cb(event))
         plotOptions:
           series:
-            events: seriesEvents
+            events: _.get(options, 'plotOptions.series.events', {})
         title: null
         credits:
           enabled: false
@@ -34,8 +31,8 @@ angular
           layout: 'vertical'
           align: 'left'
           verticalAlign: 'middle'
-          useHTML: useHTML
-          labelFormatter: labelFormatter
+          useHTML: _.get(options, 'legend.useHTML', false)
+          labelFormatter: _.get(options, 'legend.labelFormatter')
         xAxis: xAxisOptions
         yAxis:
           title: null
@@ -65,6 +62,7 @@ angular
       angular.extend(@options, options)
       chartConfig = angular.merge({}, @template(), @formatters(), @todayMarker())
       #It is faster to create a new stockChart than to update an existing one.
+        #when data changes.
       @hc = Highcharts.stockChart(@id, chartConfig)
       return @
 

--- a/src/services/highcharts-factory/highcharts-factory.svc.coffee
+++ b/src/services/highcharts-factory/highcharts-factory.svc.coffee
@@ -6,6 +6,9 @@ angular
     line: Object.freeze
       get: (series = [], options = {})->
 
+        chartOnClickCallbacks = _.get(options, 'chartOnClickCallbacks', [])
+        click = (event) -> _.each(chartOnClickCallbacks, (cb) -> cb(event))
+
         zoomingOptions = _.get(options, 'withZooming')
         xAxisOptions = if zoomingOptions?
           {
@@ -14,12 +17,13 @@ angular
             max: _.get(zoomingOptions.defaults, 'max')
             min: _.get(zoomingOptions.defaults, 'min')
           }
+
         chart:
           type: 'line'
           zoomType: 'x'
           spacingTop: 20
           events:
-            click: (event)-> _.each(_.get(options, 'chartOnClickCallbacks', []), (cb)-> cb(event))
+            click: click
         plotOptions:
           series:
             events: _.get(options, 'plotOptions.series.events', {})


### PR DESCRIPTION
@cesar-tonnoir

Instead of calling update on highCharts multiple times new data is introduced, I created an entirely new chart. For some reason I could not figure out the create method is faster than the update for the highCharts API.

Because of this, I had to change the way the options were stored, as we need to put all the options in at once.

Additionally if an input was invalid, the create and cancel buttons would not go back to normal. I solved that by adding a tostr error and invoking #cancelCreateKpi. I don't know what the intended behavior was, but you could not choose a number less than 0.

I am also not entirely confident in how the options from the specific widgets is getting integrated into the highCharts factory. It seems like _.get is being used to retrieve options from the specific widgets and injecting them into the big options-hash in `highcharts-factory.svc.coffee`. I think this could be refactored to merely merging the specific widgets' options hash with these default options, but this would take some time. For this pull request, I followed the current patterns of merging options. 