### PR TITLE
[IMPAC-848] Transactions list display bugs

### DIFF
--- a/src/components/common/transactions-list/transactions-list.less
+++ b/src/components/common/transactions-list/transactions-list.less
@@ -1,14 +1,33 @@
 #transactions-list {
   .top {
     height: 40px;
-    a.back-link { font-weight: normal; }
+    position: relative;
+
+    .back { position: absolute; }
+    .resource-type {
+      position: absolute;
+      left: ~"calc(50% - 98px)";
+      @media (max-width: @screen-xs-max) {
+        left: unset;
+        right: 0;
+      }
+    }
+    .btn-group { display: flex; }
+  }
+
+  .bottom {
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     .pagination { margin: 0px; }
   }
 
   .table-container {
-    max-height: ~"calc(@{impac-big-widget-size} - 60px)";
+    max-height: ~"calc(@{impac-big-widget-size} - 100px)";
     overflow: auto;
-    
+    width: 100%;
+
     div[uib-datepicker-popup-wrap] {
       display: inline-block;
     }

--- a/src/components/common/transactions-list/transactions-list.less
+++ b/src/components/common/transactions-list/transactions-list.less
@@ -29,5 +29,10 @@
         background-color: lighten(#c76379, 20%);
       }
     }
+
+    td > .expected-payment-date {
+      display: flex;
+      .reset-date { margin-left: 3px; }
+    }
   }
 }

--- a/src/components/common/transactions-list/transactions-list.tmpl.html
+++ b/src/components/common/transactions-list/transactions-list.tmpl.html
@@ -38,10 +38,12 @@
         <td>{{ trx.trxDateUTC }}</td>
         <td>{{ trx.dueDateUTC }}</td>
         <td ng-hide="$ctrl.listOnly">
-          <input type="text" class="btn btn-xs btn-default" uib-datepicker-popup="dd MMM yyyy" ng-model="trx.datePicker.date" ng-click="trx.datePicker.toggle()" is-open="trx.datePicker.opened" close-text="Close" on-open-focus="false" ng-change="$ctrl.changeExpectedDate(trx)"/>
-          <button class="btn btn-xs btn-danger reset-date" ng-if="trx.showReset" title="Reset expected payment date to due date" ng-click="$ctrl.resetExpectedDate(trx)">
-            <i class="fa fa-clock-o" />
-          </button>
+          <div class="expected-payment-date">
+            <input type="text" class="btn btn-xs btn-default" uib-datepicker-popup="dd MMM yyyy" ng-model="trx.datePicker.date" ng-click="trx.datePicker.toggle()" is-open="trx.datePicker.opened" close-text="Close" on-open-focus="false" ng-change="$ctrl.changeExpectedDate(trx)"/>
+            <button class="btn btn-xs btn-danger reset-date" ng-if="trx.showReset" title="Reset expected payment date to due date" ng-click="$ctrl.resetExpectedDate(trx)">
+              <i class="fa fa-clock-o" />
+            </button>
+          </div>
         </td>
         <td class="text-right">{{ trx.amount | mnoCurrency : trx.currency }}</td>
         <td class="text-right">{{ trx.balance | mnoCurrency : trx.currency }}</td>

--- a/src/components/common/transactions-list/transactions-list.tmpl.html
+++ b/src/components/common/transactions-list/transactions-list.tmpl.html
@@ -1,19 +1,16 @@
 <div id="transactions-list">
-  <div class="row top">
-    <div class="col-xs-4 pull-left">
+  <div class="top">
+    <div class="back">
       <label class="btn btn-sm btn-default" ng-click="$ctrl.onHide()" ng-hide="$ctrl.listOnly">
         <i class="fa fa-chevron-left" />
         Back to chart
       </label>
     </div>
-    <div class="col-xs-4 text-center">
+    <div class="resource-type">
       <div class="btn-group">
         <label class="btn btn-sm btn-default" ng-model="$ctrl.resourcesType" ng-click="$ctrl.changeResourcesType()" uib-btn-radio="'invoices'">See money in</label>
         <label class="btn btn-sm btn-default" ng-model="$ctrl.resourcesType" ng-click="$ctrl.changeResourcesType()" uib-btn-radio="'bills'">See money out</label>
       </div>
-    </div>
-    <div class="col-xs-4">
-      <ul uib-pagination class="pull-right" total-items="$ctrl.totalRecords" ng-model="$ctrl.currentPage" max-size="5" items-per-page="30" class="pagination-sm" force-ellipses="true" ng-change="$ctrl.changePage()"/>
     </div>
   </div>
   <div class="table-container">
@@ -60,5 +57,10 @@
         <td />
       </tr>
     </table>
+  </div>
+  <div class="bottom">
+    <div>
+      <ul uib-pagination total-items="$ctrl.totalRecords" ng-model="$ctrl.currentPage" max-size="5" items-per-page="30" class="pagination-sm" force-ellipses="true" ng-change="$ctrl.changePage()"/>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
- fixes revert date bug by using flex 
- fixes transactions list not 100% widget width < screen md size
- fixes pagination & money in / out buttons wrapping and overlapping list on smaller screen sizes

<img width="976" alt="screen shot 2018-04-23 at 18 42 51" src="https://user-images.githubusercontent.com/7486451/39145892-15a6c764-472d-11e8-88cb-058367dea494.png">
<img width="364" alt="screen shot 2018-04-23 at 19 25 58" src="https://user-images.githubusercontent.com/7486451/39145891-157f5d8c-472d-11e8-8f6c-b5d0f9e144de.png">

