### PR TITLE
[IMPAC-668] Smaller chart-threshold amount input

### DIFF
--- a/src/components/widgets-common/chart-threshold/chart-threshold.less
+++ b/src/components/widgets-common/chart-threshold/chart-threshold.less
@@ -31,6 +31,10 @@ chart-threshold {
       border-radius: 3px;
       border: 1px white;
       padding: 3px;
+
+      &[name=amount] {
+        max-width: 70px;
+      }
     }
 
     .currency {


### PR DESCRIPTION
Fixes elements wrapping, and no need for it to be so wide.

Before
<img width="1098" alt="screen shot 2018-05-10 at 11 33 23" src="https://user-images.githubusercontent.com/7486451/39865810-0349f322-5446-11e8-8d03-b4dafba98289.png">

After
<img width="1099" alt="screen shot 2018-05-10 at 11 33 35" src="https://user-images.githubusercontent.com/7486451/39865821-0b0df45a-5446-11e8-97e8-fbe88fc85dfc.png">
