### PR TITLE
Do not decode paramsHash for bolt requests

### DIFF
--- a/src/components/common/trends-add/trends-add.component.coffee
+++ b/src/components/common/trends-add/trends-add.component.coffee
@@ -44,7 +44,6 @@ module.component('trendsAdd', {
         when "Yearly" then ("Year" + (if ctrl.selectedPeriod <= 1 then "" else "s"))
 
     ctrl.dataIsValid = ->
-      ctrl.trend.rate != 0 &&
       ctrl.trend.untilDate? &&
       !_.isEmpty(ctrl.trend.account)
 

--- a/src/components/common/trends-add/trends-add.component.coffee
+++ b/src/components/common/trends-add/trends-add.component.coffee
@@ -101,7 +101,10 @@ module.component('trendsAdd', {
     ctrl.redrawCurrentTrend = ->
       return unless ctrl.dataIsValid()
       _.remove(ctrl.chart.series, {name: "Current trend"})
-      newSerie = angular.copy(_.find(ctrl.chart.series, 'name', 'Projected cash'))
+      if ctrl.trend.trends_group && !ctrl.isAddingGroup
+        originalSerie = _.find(ctrl.chart.series, 'name', ctrl.trend.trends_group.attributes.name)
+      originalSerie ?= _.find(ctrl.chart.series, 'name', 'Projected cash')
+      newSerie = angular.copy(originalSerie)
       accountBalance = _.find(ctrl.accountsLastValues, (hash) ->
         return hash.label == ctrl.trend.account.id
       )['value'][ctrl.trend.period.toLowerCase()]

--- a/src/components/common/trends-add/trends-add.tmpl.html
+++ b/src/components/common/trends-add/trends-add.tmpl.html
@@ -35,7 +35,7 @@
 
         <label>Group: </label>
         <div ng-if="!$ctrl.isAddingGroup">
-          <select ng-model="$ctrl.trend.trends_group" ng-options="group.attributes.name for group in $ctrl.groups | orderBy: 'attributes.name' track by group.id" class='form-control'>
+          <select ng-model="$ctrl.trend.trends_group" ng-options="group.attributes.name for group in $ctrl.groups | orderBy: 'attributes.name' track by group.id" ng-change="$ctrl.redrawCurrentTrend()" class='form-control'>
             <option value=''> Choose a group</option>
           </select>
           <i class="fa fa-plus-square" title="Create a new group" ng-click="$ctrl.switchAddingGroup(true)"/>

--- a/src/components/widgets-layouts/custom/accounts-cash-projection/accounts-cash-projection.directive.coffee
+++ b/src/components/widgets-layouts/custom/accounts-cash-projection/accounts-cash-projection.directive.coffee
@@ -416,6 +416,23 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, $tim
         $scope.userId = response.data.data.id
     ) if $scope.firstCompanyId
 
+  fetchUser = ->
+    # Fetch or create user from Bolt
+    BoltResources.index(
+      w.metadata.bolt_path,
+      'users',
+      {
+        filter: { email: ImpacMainSvc.config.userData.email },
+        metadata: _.pick(w.metadata, 'organization_ids')
+      }
+    ).then((response) ->
+      if response.data.meta.record_count > 0
+        $scope.userId = response.data.data[0].id
+      else
+        createUser()
+    )
+
+
   # == Widget =====================================================================================
   # Executed after the widget content is retrieved from the API
   w.initContext = ->
@@ -439,24 +456,10 @@ module.controller('WidgetAccountsCashProjectionCtrl', ($scope, $q, $filter, $tim
       else
         w.demoData = false
         $scope.firstCompanyId = response.data.data[0].id
+        fetchUser()
       loadContacts()
       loadAccounts()
       loadTrendsGroups()
-    )
-
-    # Fetch or create user from Bolt
-    BoltResources.index(
-      w.metadata.bolt_path,
-      'users',
-      {
-        filter: { email: ImpacMainSvc.config.userData.email },
-        metadata: _.pick(w.metadata, 'organization_ids')
-      }
-    ).then((response) ->
-      if response.data.meta.record_count > 0
-        $scope.userId = response.data.data[0].id
-      else
-        createUser()
     )
 
   # Executed after the widget and its settings are initialised and ready

--- a/src/services/bolt-resources/bolt-resources.svc.coffee
+++ b/src/services/bolt-resources/bolt-resources.svc.coffee
@@ -8,8 +8,7 @@ angular
 
   buildUrl = (pathArray, paramsHash) ->
     url = pathArray.join('/')
-    params = decodeURIComponent( $.param(paramsHash) )
-    [url, params].join('?')
+    [url, $.param(paramsHash)].join('?')
 
   @index = (boltPath, resourcesName, params) ->
     url = buildUrl([boltPath, resourcesName], params)


### PR DESCRIPTION
- For the method createUser, we need the firstCompanyId, which may not have been fetched before

- When requesting an index on the bolt, the params were decoded.
As a result, "emmanuel+1@maestrano.com" would be sent as is in the request params, the '+' not being encoded making the request fail