### PR TITLE
[IMPAC-792] Hotfix table highstocks width expanding

### DIFF
--- a/src/components/widgets-layouts/generic-templates/table-highstocks/table-highstocks.directive.coffee
+++ b/src/components/widgets-layouts/generic-templates/table-highstocks/table-highstocks.directive.coffee
@@ -51,7 +51,7 @@ module.controller('WidgetTableHighstocksCtrl', ($scope, $q, $filter, $timeout, I
     _.include($scope.selectedElements, id)
 
   $scope.hasElements = ->
-    !_.isEmpty($scope.selectedElements)
+    !_.isEmpty($scope.selectedElements) && (w.width = 12)
 
   # Unique identifier for the chart object in the DOM
   $scope.chartId = ->


### PR DESCRIPTION
When elements are selected this fix sets the widget width to 12, it was
not working before as this layout was developed when impac api was
returning all v2 widgets as width 12.

@agranado2k please review & merge accordingly. I have detailed the ticket with testing steps, so once deployed this should be good to go straight to QA. 