### PR TITLE
[KAPP-175]  Allow runtime services configuration

### DIFF
--- a/src/services/routes/routes.svc.coffee
+++ b/src/services/routes/routes.svc.coffee
@@ -85,6 +85,9 @@ angular
       #=======================================
       # Public methods available as service
       #=======================================
+      service.configureRoutes = (configOptions) ->
+        angular.extend(defaults, configOptions)
+
       service.dashboards =
         index: (orgId=null) ->
           if defaults.dashboards.index

--- a/src/services/theming/theming.svc.coffee
+++ b/src/services/theming/theming.svc.coffee
@@ -147,6 +147,9 @@ angular
       service.get = ->
         return options
 
+      service.configure = (configOptions) ->
+        angular.merge(options, configOptions)
+
       service.getDhbLabelName = ->
         designerModeOpts = options.dhbConfig.designerMode
         if designerModeOpts.enabled then designerModeOpts.dhbLabelName else 'Dashboard'


### PR DESCRIPTION
This allow the admin panel to switch Impac configuration between staff
dashboards and designer mode in different parts of the application.

__Note:__ I've used the same method  as the `provider.configure` which is why we have `extend` and `merge`
Ok to review but I'd wait for extensive testing and QA before merging