### PR TITLE
Fix dashboard creation

### DIFF
--- a/src/components/dashboard-create/dashboard-create.component.coffee
+++ b/src/components/dashboard-create/dashboard-create.component.coffee
@@ -58,7 +58,9 @@ module.component('impacDashboardCreate', {
         _.isEmpty(ctrl.modalScope.dashboard.name) || !_.some(_.pluck(ctrl.modalScope.organizations, 'selected'))
 
     ctrl.openModal = ->
-      ctrl.modalScope.dashboard.name = null
+      # Re-init the modal scope when opening the modal
+      # Otherwise previous dashboard options are kept when creating multiple dashboard in a row
+      ctrl.modalScope.dashboard = {}
       ctrl.modalScope.source.mode = 'single'
       modalConfig =
         backdrop: 'static'


### PR DESCRIPTION
Reset the dashboard in scope when opening the modal.
Otherwise the previous dashboard settings are kept.

This fixes the following bug:
- Create a dashboard from a template
- Create a dashboard from scratch
=> The 2nd dashboard is a copy of the template because [dashboard.id is
stil set](https://github.com/maestrano/impac-angular/blob/v1.8.5/src/components/dashboard/dashboard.directive.coffee#L136-L139)